### PR TITLE
Fix TypeScript compilation errors in ContextWindowPanel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2758,7 +2758,15 @@ function App() {
                       <div className="flex h-full flex-col gap-4 p-5 retro-right-stack">
                         {/* Context Window Panel — character sheet and dice history */}
                         <ContextWindowPanel
-                          playerState={playerState ?? undefined}
+                          playerState={playerState ? {
+                            currentLevel: playerState.currentLevel ?? undefined,
+                            currentXP: playerState.currentXP ?? undefined,
+                            xpToNextLevel: playerState.xpToNextLevel ?? undefined,
+                            currentAreaId: playerState.currentAreaId ?? undefined,
+                            lastKnownLocation: playerState.lastKnownLocation ?? undefined,
+                            diceRollLog: playerState.diceRollLog as any ?? undefined,
+                            pendingDiceRoll: playerState.pendingDiceRoll ?? undefined,
+                          } : undefined}
                           character={{
                             name: characterDisplay.name,
                             level: characterDisplay.level,

--- a/src/components/ContextWindowPanel.tsx
+++ b/src/components/ContextWindowPanel.tsx
@@ -29,8 +29,6 @@ interface ContextWindowPanelProps {
     currentLevel?: number;
     currentXP?: number;
     xpToNextLevel?: number;
-    currentHP?: number;
-    maxHP?: number;
     currentAreaId?: string;
     lastKnownLocation?: string;
     diceRollLog?: DiceRollEntry[];
@@ -90,8 +88,8 @@ function ContextWindowPanel({
           <CharacterSheetPanel
             name={character?.name}
             level={character?.level ?? playerState?.currentLevel}
-            currentHP={character?.currentHP ?? playerState?.currentHP}
-            maxHP={character?.maxHP ?? playerState?.maxHP}
+            currentHP={character?.currentHP}
+            maxHP={character?.maxHP}
             currentXP={playerState?.currentXP}
             xpToNextLevel={playerState?.xpToNextLevel}
             stats={character?.stats as CharacterSheetPanelProps['stats']}


### PR DESCRIPTION
- Updated playerState prop to only include fields that exist in PlayerState schema
- Removed currentHP and maxHP from playerState type (these come from character)
- Fixed null/undefined type handling by explicitly mapping playerState fields
- Build now completes successfully