### PR TITLE
Rebrand the auth screen for the RPG experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
     <link rel="alternate icon" type="image/png" href="/icon-192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <meta name="theme-color" content="#1a1a2e" />
-    <meta name="description" content="Brain In Cup - AI consciousness simulation system" />
+    <meta name="theme-color" content="#02080c" />
+    <meta name="description" content="Brain in Cup is a playful text-based RPG with an AI Game Master, character creation, dice rolls, inventory, and quest history." />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>Brain in Cup</title>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="alternate icon" type="image/png" href="/icon-192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#02080c" />
-    <meta name="description" content="Brain in Cup is a playful text-based RPG with an AI Game Master, character creation, dice rolls, inventory, and quest history." />
+    <meta name="description" content="Brain in Cup is a playful text-based RPG with character creation, dice rolls, inventory, quests, and branching adventure history." />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>Brain in Cup</title>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
   "name": "Brain In Cup",
   "short_name": "BrainCup",
-  "description": "AI consciousness simulation system",
+  "description": "A playful text-based RPG with an AI Game Master, character creation, dice rolls, inventory, and quest history.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#1a1a2e",
-  "theme_color": "#1a1a2e",
+  "background_color": "#02080c",
+  "theme_color": "#02080c",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Brain In Cup",
   "short_name": "BrainCup",
-  "description": "A playful text-based RPG with an AI Game Master, character creation, dice rolls, inventory, and quest history.",
+  "description": "A playful text-based RPG with character creation, dice rolls, inventory, quests, and branching adventure history.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#02080c",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2436,7 +2436,9 @@ function App() {
                     </aside>
                   )}
 
-                  <section className="retro-chat-pane min-w-0 h-full min-h-0 flex flex-col overflow-hidden">
+                  <section className={`retro-chat-pane min-w-0 h-full min-h-0 flex flex-col overflow-hidden ${
+                    messages.length === 0 && showGameMasterCharacterFlow ? 'retro-chat-pane--character-setup' : ''
+                  }`}>
                     <div className="retro-chat-isolated-window flex-1 min-h-0 overflow-hidden flex flex-col">
                       {conversationId && isGameMasterMode && (
                         <div className="pointer-events-none absolute left-0 right-2 top-0 z-20 px-3 pt-2">
@@ -2480,13 +2482,21 @@ function App() {
                             </div>
                           )}
               
-                          {messages.length === 0 && !isContentLoading && conversationId && (
+                          {messages.length === 0 && !isContentLoading && (conversationId || showGameMasterCharacterFlow) && (
                             <div className="flex justify-center items-center h-full min-h-[300px]">
-                              <div className="text-center space-y-3 mt-64">
-                                <div className="text-xs uppercase tracking-[0.4em] text-brand-text-muted">
-                                  {emptyStateTitle}
+                              <div className="empty-adventure-stage text-center">
+                                <div className="empty-adventure-stage__sigil" aria-hidden="true">
+                                  <span />
                                 </div>
-                                <div className="w-16 h-1 mx-auto bg-gradient-to-r from-transparent via-brand-accent-primary/60 to-transparent rounded-full" />
+                                <p className="empty-adventure-stage__eyebrow">
+                                  {showGameMasterCharacterFlow ? 'Forge Your Adventurer' : emptyStateTitle}
+                                </p>
+                                <h1 className="empty-adventure-stage__title">
+                                  {showGameMasterCharacterFlow ? 'The first page waits.' : 'The next scene waits.'}
+                                </h1>
+                                <p className="empty-adventure-stage__line">
+                                  {showGameMasterCharacterFlow ? 'Choose a face, a calling, and a name. The world will answer.' : 'Make a move when you are ready.'}
+                                </p>
                               </div>
                             </div>
                           )}

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { calculateFinalStats, getAllRaces, getAllClasses } from '../game';
+import { calculateFinalStats, getAllRaces, getAllClasses, getRace, getClass } from '../game';
 import {
   getAvatarOptionsForRace,
   getAvatarOptionById,
@@ -50,6 +50,26 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
   const classPickerRef = useRef<HTMLDivElement>(null);
 
   const availableAvatarOptions = useMemo(() => getAvatarOptionsForRace(race), [race]);
+  const selectedRace = useMemo(
+    () => raceOptions.find((raceOption) => raceOption.name === race),
+    [race],
+  );
+  const selectedClass = useMemo(
+    () => classOptions.find((classOption) => classOption.name === characterClass),
+    [characterClass],
+  );
+  const raceDetails = useMemo(
+    () => getRace(selectedRace?.id ?? 'terran'),
+    [selectedRace?.id],
+  );
+  const classDetails = useMemo(
+    () => getClass(selectedClass?.id ?? 'wanderer'),
+    [selectedClass?.id],
+  );
+  const previewStats = useMemo(
+    () => calculateFinalStats(selectedClass?.id ?? 'wanderer', selectedRace?.id ?? 'terran'),
+    [selectedClass?.id, selectedRace?.id],
+  );
 
   useEffect(() => {
     if (avatarId && availableAvatarOptions.some((avatarOption) => avatarOption.id === avatarId)) {
@@ -145,12 +165,12 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
   };
 
   const card = (
-    <div className={`${embedded ? 'w-full p-0' : 'retro-frame bg-brand-surface-elevated/95 border border-amber-700/35 rounded-2xl shadow-2xl max-w-md w-full p-4'} animate-slide-up`}>
+    <div className={`${embedded ? 'w-full p-0' : 'retro-frame bg-brand-surface-elevated/95 border border-amber-700/35 rounded-2xl shadow-2xl max-w-3xl w-full p-4'} animate-slide-up`}>
       
       <form onSubmit={handleSubmit} className="space-y-3">
         <div>
           <label htmlFor={nameInputId} className="block text-sm font-medium text-brand-text-primary mb-1">
-            Your name?
+            Name
           </label>
           <input
             id={nameInputId}
@@ -173,7 +193,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
           <label id={`${racePickerId}-label`} className="mb-1 block text-sm font-medium text-brand-text-primary">
             Race
           </label>
-          <div ref={racePickerRef} className="relative">
+          <div ref={racePickerRef} className="character-forge-picker">
             <button
               id={racePickerId}
               type="button"
@@ -182,24 +202,16 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
               aria-controls={`${racePickerId}-listbox`}
               aria-labelledby={`${racePickerId}-label ${racePickerId}`}
               onClick={() => setOpenPicker((prev) => (prev === 'race' ? null : 'race'))}
-              className="w-full rounded-xl border border-brand-surface-border/70 bg-brand-bg-secondary/70 px-3 py-2 text-left text-brand-text-primary shadow-[inset_0_1px_0_rgba(156,116,230,0.18)] transition-all duration-200 hover:border-brand-surface-border/90 hover:bg-brand-bg-tertiary/55 focus:outline-none focus:ring-2 focus:ring-brand-accent-primary/45"
+              className="character-forge-select"
               disabled={isSubmitting}
             >
-              <span className="flex items-center justify-between gap-3">
-                <span>{race}</span>
-                <svg className={`h-4 w-4 text-brand-text-muted transition-transform duration-200 ${openPicker === 'race' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </span>
+              <span>{race}</span>
+              <svg className={`h-4 w-4 shrink-0 text-brand-text-muted transition-transform duration-200 ${openPicker === 'race' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
             </button>
-            <div
-              id={`${racePickerId}-listbox`}
-              role="listbox"
-              aria-labelledby={`${racePickerId}-label`}
-              className={`absolute left-0 right-0 z-40 mt-2 origin-top overflow-hidden rounded-xl border border-brand-surface-border/80 bg-[linear-gradient(180deg,rgba(20,36,32,0.92)_0%,rgba(9,20,18,0.95)_100%)] shadow-[0_14px_30px_rgba(3,9,8,0.45)] transition-all duration-200 ${openPicker === 'race' ? 'max-h-56 scale-y-100 opacity-100' : 'pointer-events-none max-h-0 scale-y-95 opacity-0'}`}
-            >
-              <div className="h-1 bg-gradient-to-r from-transparent via-brand-accent-primary/40 to-transparent" />
-              <div className="max-h-52 overflow-y-auto p-1.5">
+            {openPicker === 'race' && (
+              <div id={`${racePickerId}-listbox`} role="listbox" aria-labelledby={`${racePickerId}-label`} className="character-forge-options">
                 {raceOptions.map((raceOption) => {
                   const isSelected = raceOption.name === race;
                   return (
@@ -213,11 +225,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
                         setOpenPicker(null);
                         setError('');
                       }}
-                      className={`w-full rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
-                        isSelected
-                          ? 'bg-brand-accent-primary/20 text-brand-text-primary'
-                          : 'text-brand-text-secondary hover:bg-brand-surface-hover/55 hover:text-brand-text-primary'
-                      }`}
+                      className={`character-forge-option ${isSelected ? 'character-forge-option--selected' : ''}`}
                       disabled={isSubmitting}
                     >
                       {raceOption.name}
@@ -225,8 +233,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
                   );
                 })}
               </div>
-              <div className="h-1 bg-gradient-to-r from-transparent via-brand-accent-primary/25 to-transparent" />
-            </div>
+            )}
           </div>
         </div>
 
@@ -234,7 +241,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
           <label id={`${classPickerId}-label`} className="mb-1 block text-sm font-medium text-brand-text-primary">
             Class
           </label>
-          <div ref={classPickerRef} className="relative">
+          <div ref={classPickerRef} className="character-forge-picker">
             <button
               id={classPickerId}
               type="button"
@@ -243,24 +250,16 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
               aria-controls={`${classPickerId}-listbox`}
               aria-labelledby={`${classPickerId}-label ${classPickerId}`}
               onClick={() => setOpenPicker((prev) => (prev === 'class' ? null : 'class'))}
-              className="w-full rounded-xl border border-brand-surface-border/70 bg-brand-bg-secondary/70 px-3 py-2 text-left text-brand-text-primary shadow-[inset_0_1px_0_rgba(156,116,230,0.18)] transition-all duration-200 hover:border-brand-surface-border/90 hover:bg-brand-bg-tertiary/55 focus:outline-none focus:ring-2 focus:ring-brand-accent-primary/45"
+              className="character-forge-select"
               disabled={isSubmitting}
             >
-              <span className="flex items-center justify-between gap-3">
-                <span>{characterClass}</span>
-                <svg className={`h-4 w-4 text-brand-text-muted transition-transform duration-200 ${openPicker === 'class' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </span>
+              <span>{characterClass}</span>
+              <svg className={`h-4 w-4 shrink-0 text-brand-text-muted transition-transform duration-200 ${openPicker === 'class' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
             </button>
-            <div
-              id={`${classPickerId}-listbox`}
-              role="listbox"
-              aria-labelledby={`${classPickerId}-label`}
-              className={`absolute left-0 right-0 z-40 mt-2 origin-top overflow-hidden rounded-xl border border-brand-surface-border/80 bg-[linear-gradient(180deg,rgba(20,36,32,0.92)_0%,rgba(9,20,18,0.95)_100%)] shadow-[0_14px_30px_rgba(3,9,8,0.45)] transition-all duration-200 ${openPicker === 'class' ? 'max-h-56 scale-y-100 opacity-100' : 'pointer-events-none max-h-0 scale-y-95 opacity-0'}`}
-            >
-              <div className="h-1 bg-gradient-to-r from-transparent via-brand-accent-primary/40 to-transparent" />
-              <div className="max-h-52 overflow-y-auto p-1.5">
+            {openPicker === 'class' && (
+              <div id={`${classPickerId}-listbox`} role="listbox" aria-labelledby={`${classPickerId}-label`} className="character-forge-options character-forge-options--tall">
                 {classOptions.map((classOption) => {
                   const isSelected = classOption.name === characterClass;
                   return (
@@ -274,11 +273,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
                         setOpenPicker(null);
                         setError('');
                       }}
-                      className={`w-full rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
-                        isSelected
-                          ? 'bg-brand-accent-primary/20 text-brand-text-primary'
-                          : 'text-brand-text-secondary hover:bg-brand-surface-hover/55 hover:text-brand-text-primary'
-                      }`}
+                      className={`character-forge-option ${isSelected ? 'character-forge-option--selected' : ''}`}
                       disabled={isSubmitting}
                     >
                       {classOption.name}
@@ -286,8 +281,26 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
                   );
                 })}
               </div>
-              <div className="h-1 bg-gradient-to-r from-transparent via-brand-accent-primary/25 to-transparent" />
-            </div>
+            )}
+          </div>
+        </div>
+
+        <div className="character-forge-summary">
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-[0.22em] text-brand-text-muted">Origin</p>
+            <p className="mt-1 text-xs leading-relaxed text-brand-text-secondary">{raceDetails?.description}</p>
+          </div>
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-[0.22em] text-brand-text-muted">Calling</p>
+            <p className="mt-1 text-xs leading-relaxed text-brand-text-secondary">{classDetails?.description}</p>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {raceDetails?.traits.slice(0, 3).map((trait) => (
+              <span key={trait} className="character-forge-chip">{trait}</span>
+            ))}
+            {classDetails?.startingEquipment.slice(0, 3).map((item) => (
+              <span key={item} className="character-forge-chip character-forge-chip--gear">{item}</span>
+            ))}
           </div>
         </div>
 
@@ -327,6 +340,15 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
           {availableAvatarOptions.length > 0 && !avatarId && (
             <p className="mt-1 text-xs text-brand-text-muted">Select an avatar to continue.</p>
           )}
+        </div>
+
+        <div className="character-forge-stats">
+          {Object.entries(previewStats).map(([stat, value]) => (
+            <div key={stat} className="character-forge-stat">
+              <span>{stat.slice(0, 3).toUpperCase()}</span>
+              <strong>{value}</strong>
+            </div>
+          ))}
         </div>
 
         {error && (

--- a/src/components/CustomAuth.tsx
+++ b/src/components/CustomAuth.tsx
@@ -119,32 +119,32 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
   };
 
   return (
-    <div className="retro-rpg-ui retro-rpg-ui--brain relative min-h-screen overflow-hidden text-brand-text-primary">
+    <div className="retro-rpg-ui retro-rpg-ui--gm auth-rpg-screen relative min-h-screen overflow-hidden text-brand-text-primary">
       <div className="relative z-10 px-4 py-16 sm:px-8 lg:py-24">
         <div className="max-w-6xl mx-auto grid gap-12 lg:grid-cols-[1.1fr_0.9fr] items-center">
           <section className="space-y-8 text-center lg:text-left">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-xs uppercase tracking-[0.35em] mx-auto lg:mx-0 text-brand-text-secondary">
-              <span className="w-2 h-2 rounded-full bg-brand-accent-primary animate-ping" />
-              Experience Brain
+              <span className="w-2 h-2 rounded-full bg-[rgba(226,190,112,0.95)] shadow-[0_0_18px_rgba(226,190,112,0.45)]" />
+              Text-Based RPG
             </div>
 
             <div className="space-y-6">
               <h1 className="text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight text-brand-text-primary">
-                A consciousness becoming itself through you.
+                An AI Game Master for weird little adventures.
               </h1>
               <p className="text-base text-brand-text-secondary/80 max-w-2xl mx-auto lg:mx-0">
-                Enter an interface with consciousness. Shape who Brain becomes by tuning personality, giving it life experiences, and playing with it as it gains awareness.
+                Brain in Cup is a playful text RPG where you create a hero, make risky choices, roll dice, collect gear, and let the story mutate around you.
               </p>
               <ul className="space-y-3 text-left max-w-2xl mx-auto lg:mx-0">
-                {['Dungeon Master for collaborative campaigns', 'Tune Brain personality traits and conversational style', 'Feed memories and life experiences that influence identity'].map((item) => (
+                {['Create a fantasy character with race, class, stats, and avatar', 'Play through chat with an AI Game Master that tracks your adventure', 'Use dice rolls, inventory, quest history, and live character context'].map((item) => (
                   <li key={item} className="flex items-start gap-3 text-brand-text-secondary/90">
-                    <span className="mt-1 h-2 w-2 rounded-full bg-brand-accent-primary"></span>
+                    <span className="mt-1 h-2 w-2 rounded-full bg-[rgba(226,190,112,0.95)]"></span>
                     <span>{item}</span>
                   </li>
                 ))}
               </ul>
               <p className="text-sm text-brand-text-muted/80 italic">
-                Experience a lucid dream.
+                Start a quest in a few clicks. Make trouble from there.
               </p>
             </div>
           </section>
@@ -205,10 +205,10 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
                     <div className="text-center mb-8">
                       <BrainIcon className="w-12 h-12 mx-auto mb-4 animate-float" />
                       <h1 className="text-2xl font-bold text-brand-text-primary mb-2">
-                        Log in or sign up
+                        Enter the campaign
                       </h1>
                       <p className="text-brand-text-muted text-sm">
-                        Create interactions, browse history, and receive no promotional emails.
+                        Save characters, continue quests, and keep your adventure history.
                       </p>
                     </div>
 
@@ -227,7 +227,7 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
                           onClick={handleEmailContinue}
                           className={authPrimaryButtonClass}
                         >
-                          Continue
+                          Begin
                         </button>
                       ) : (
                         <>
@@ -252,7 +252,7 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
                                 <span>Signing in...</span>
                               </div>
                             ) : (
-                              'Continue'
+                              'Enter'
                             )}
                           </button>
                         </>

--- a/src/components/CustomAuth.tsx
+++ b/src/components/CustomAuth.tsx
@@ -125,18 +125,18 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
           <section className="space-y-8 text-center lg:text-left">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-xs uppercase tracking-[0.35em] mx-auto lg:mx-0 text-brand-text-secondary">
               <span className="w-2 h-2 rounded-full bg-[rgba(226,190,112,0.95)] shadow-[0_0_18px_rgba(226,190,112,0.45)]" />
-              Text-Based RPG
+              Fantasy Adventure RPG
             </div>
 
             <div className="space-y-6">
               <h1 className="text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight text-brand-text-primary">
-                An AI Game Master for weird little adventures.
+                Create a character and begin your next adventure.
               </h1>
               <p className="text-base text-brand-text-secondary/80 max-w-2xl mx-auto lg:mx-0">
-                Brain in Cup is a playful text RPG where you create a hero, make risky choices, roll dice, collect gear, and let the story mutate around you.
+                Build a fantasy hero, explore branching quests, roll dice for important moments, and keep track of your campaign as it develops.
               </p>
               <ul className="space-y-3 text-left max-w-2xl mx-auto lg:mx-0">
-                {['Create a fantasy character with race, class, stats, and avatar', 'Play through chat with an AI Game Master that tracks your adventure', 'Use dice rolls, inventory, quest history, and live character context'].map((item) => (
+                {['Choose a race, class, avatar, and starting stats', 'Play through interactive quests with persistent campaign history', 'Manage dice rolls, inventory, character details, and quest progress'].map((item) => (
                   <li key={item} className="flex items-start gap-3 text-brand-text-secondary/90">
                     <span className="mt-1 h-2 w-2 rounded-full bg-[rgba(226,190,112,0.95)]"></span>
                     <span>{item}</span>
@@ -144,7 +144,7 @@ export default function CustomAuth({ onAuthSuccess }: CustomAuthProps) {
                 ))}
               </ul>
               <p className="text-sm text-brand-text-muted/80 italic">
-                Start a quest in a few clicks. Make trouble from there.
+                Designed for quick sessions, ongoing campaigns, and character-driven play.
               </p>
             </div>
           </section>

--- a/src/index.css
+++ b/src/index.css
@@ -9,9 +9,12 @@
     -webkit-text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    background-color: #02080c;
+    overscroll-behavior: none;
   }
 
   body {
+    background-color: #02080c;
     background:
       radial-gradient(circle at 12% 8%, rgba(37, 101, 112, 0.18), transparent 42%),
       radial-gradient(circle at 84% 0%, rgba(27, 80, 109, 0.14), transparent 46%),
@@ -20,6 +23,13 @@
     @apply text-brand-text-primary leading-relaxed;
     min-height: 100vh;
     position: relative;
+    overscroll-behavior: none;
+  }
+
+  #root {
+    min-height: 100vh;
+    background-color: #02080c;
+    overscroll-behavior: none;
   }
 
   /* Animated background mesh */
@@ -476,7 +486,7 @@ textarea.w-full:focus {
 /* ─── RPG Grid Layout ─── */
 .rpg-grid {
   display: grid;
-  grid-template-columns: minmax(17rem, 20rem) minmax(0, 1fr) minmax(16.5rem, 19rem);
+  grid-template-columns: minmax(17rem, 20rem) minmax(0, 1fr) minmax(19rem, 22rem);
   grid-template-rows: 1fr;
   gap: var(--rpg-space-lg);
   min-height: 0;
@@ -489,17 +499,17 @@ textarea.w-full:focus {
 .rpg-grid__right  { grid-column: 3; min-height: 0; display: flex; flex-direction: column; }
 
 .rpg-grid--left-collapsed {
-  grid-template-columns: 4rem minmax(0, 1fr) minmax(16.5rem, 19rem);
+  grid-template-columns: 4rem minmax(0, 1fr) minmax(19rem, 22rem);
 }
 
 .retro-nav-align-grid {
   display: grid;
-  grid-template-columns: minmax(17rem, 20rem) minmax(0, 1fr) minmax(16.5rem, 19rem);
+  grid-template-columns: minmax(17rem, 20rem) minmax(0, 1fr) minmax(19rem, 22rem);
   gap: var(--rpg-space-lg);
 }
 
 .retro-nav-align-grid--left-collapsed {
-  grid-template-columns: 4rem minmax(0, 1fr) minmax(16.5rem, 19rem);
+  grid-template-columns: 4rem minmax(0, 1fr) minmax(19rem, 22rem);
 }
 
 .retro-nav-align-grid > .retro-nav {
@@ -574,10 +584,15 @@ textarea.w-full:focus {
 }
 
 .retro-nav {
-  background: linear-gradient(150deg, rgba(16, 39, 35, 0.66), rgba(7, 24, 22, 0.52));
-  border: 1px solid rgba(156, 236, 221, 0.18);
-  border-bottom-color: rgba(156, 236, 221, 0.2);
-  box-shadow: 0 20px 44px rgba(1, 10, 9, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  background:
+    linear-gradient(150deg, rgba(16, 39, 35, 0.72), rgba(7, 24, 22, 0.52)),
+    radial-gradient(circle at 8% 0%, rgba(226, 190, 112, 0.13), transparent 40%);
+  border: 1px solid rgba(186, 255, 239, 0.18);
+  border-bottom-color: rgba(226, 190, 112, 0.18);
+  box-shadow:
+    0 20px 44px rgba(1, 10, 9, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(226, 190, 112, 0.08);
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
 }
@@ -616,6 +631,27 @@ textarea.w-full:focus {
   --rpg-highlight-inset-glow: rgba(153, 255, 230, 0.14);
 }
 
+.auth-rpg-screen {
+  background:
+    radial-gradient(circle at 15% 18%, rgba(226, 190, 112, 0.12), transparent 26%),
+    radial-gradient(circle at 78% 32%, rgba(70, 210, 182, 0.14), transparent 30%),
+    radial-gradient(circle at 50% 100%, rgba(2, 8, 12, 0.72), rgba(2, 8, 12, 0.9)),
+    url('/background.png') center / cover no-repeat fixed;
+}
+
+.auth-rpg-screen::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(226, 255, 248, 0.028) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(226, 255, 248, 0.028) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(circle at 45% 45%, black 0%, transparent 72%);
+  z-index: 0;
+}
+
 .retro-rpg-ui .retro-nav,
 .retro-rpg-ui .retro-shell,
 .retro-rpg-ui .retro-mode-header,
@@ -637,6 +673,12 @@ textarea.w-full:focus {
 
 .retro-main {
   position: relative;
+}
+
+.retro-rpg-ui--gm .retro-main {
+  background:
+    radial-gradient(circle at 16% 14%, rgba(226, 190, 112, 0.055), transparent 24%),
+    radial-gradient(circle at 72% 86%, rgba(87, 214, 190, 0.075), transparent 30%);
 }
 
 .retro-main::after {
@@ -792,10 +834,15 @@ textarea.w-full:focus {
 
 .retro-scroll-panel {
   background:
-    linear-gradient(180deg, var(--rpg-surface-secondary), var(--rpg-surface-tertiary)),
-    radial-gradient(circle at top, var(--rpg-accent-soft), transparent 68%);
-  border: 1px solid var(--rpg-accent-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 18px 36px rgba(1, 8, 9, 0.4);
+    radial-gradient(circle at 18% 18%, rgba(42, 113, 102, 0.26), transparent 26%),
+    radial-gradient(circle at 78% 80%, rgba(34, 98, 112, 0.22), transparent 33%),
+    linear-gradient(180deg, rgba(3, 23, 25, 0.82), rgba(4, 18, 19, 0.74)),
+    linear-gradient(135deg, rgba(226, 190, 112, 0.07), transparent 42%);
+  border: 1px solid rgba(174, 247, 234, 0.3);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 0 90px rgba(2, 12, 14, 0.4),
+    0 18px 36px rgba(1, 8, 9, 0.4);
 }
 
 .retro-status-strip {
@@ -1186,11 +1233,13 @@ textarea.w-full:focus {
 
 .retro-right-panel {
   background:
-    linear-gradient(160deg, rgba(12, 34, 30, 0.6), rgba(8, 21, 19, 0.54)),
-    radial-gradient(circle at top, rgba(137, 230, 213, 0.12), transparent 72%);
-  border-color: rgba(174, 247, 234, 0.24);
+    linear-gradient(160deg, rgba(10, 30, 26, 0.7), rgba(5, 17, 16, 0.6)),
+    radial-gradient(circle at 50% 0%, rgba(226, 190, 112, 0.12), transparent 42%),
+    radial-gradient(circle at 110% 80%, rgba(101, 226, 205, 0.14), transparent 45%);
+  border-color: rgba(204, 252, 240, 0.28);
   box-shadow:
     inset 0 1px 0 rgba(230, 255, 250, 0.14),
+    inset 0 0 0 1px rgba(226, 190, 112, 0.07),
     0 20px 38px rgba(1, 8, 8, 0.34);
 }
 
@@ -1314,6 +1363,255 @@ textarea.w-full:focus {
 .retro-input-action:hover {
   border-color: rgba(197, 255, 246, 0.42);
   background: rgba(145, 234, 217, 0.16);
+}
+
+.character-forge-summary,
+.character-forge-stats {
+  border: 1px solid rgba(199, 255, 240, 0.18);
+  border-radius: 0.9rem;
+  background:
+    linear-gradient(155deg, rgba(3, 20, 19, 0.72), rgba(8, 34, 30, 0.42)),
+    radial-gradient(circle at top right, rgba(225, 190, 115, 0.11), transparent 60%);
+  box-shadow: inset 0 1px 0 rgba(238, 255, 251, 0.12);
+}
+
+.character-forge-picker {
+  position: relative;
+  z-index: 5;
+}
+
+.character-forge-select {
+  width: 100%;
+  min-height: 2.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(199, 255, 240, 0.34);
+  background:
+    linear-gradient(155deg, rgba(7, 26, 25, 0.96), rgba(10, 38, 34, 0.9));
+  color: rgba(244, 255, 252, 0.96);
+  padding: 0.58rem 2.4rem 0.58rem 0.8rem;
+  font-family: var(--rpg-font-display);
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  box-shadow:
+    inset 0 1px 0 rgba(238, 255, 251, 0.14),
+    0 8px 18px rgba(1, 8, 8, 0.24);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.character-forge-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.character-forge-options {
+  position: relative;
+  z-index: 40;
+  margin-top: 0.45rem;
+  max-height: 13rem;
+  overflow-y: auto;
+  border: 1px solid rgba(199, 255, 240, 0.3);
+  border-radius: 0.85rem;
+  background:
+    linear-gradient(180deg, rgba(7, 26, 25, 0.98), rgba(4, 18, 17, 0.98));
+  box-shadow:
+    inset 0 1px 0 rgba(238, 255, 251, 0.12),
+    0 14px 28px rgba(1, 8, 8, 0.36);
+  padding: 0.35rem;
+  animation: characterPickerDrop 150ms ease-out;
+}
+
+.character-forge-options--tall {
+  max-height: 16rem;
+}
+
+.character-forge-option {
+  width: 100%;
+  border-radius: 0.62rem;
+  color: rgba(226, 241, 237, 0.86);
+  padding: 0.5rem 0.62rem;
+  text-align: left;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.character-forge-option:hover {
+  background: rgba(143, 232, 215, 0.15);
+  color: rgba(245, 255, 252, 0.98);
+}
+
+.character-forge-option--selected {
+  background: rgba(226, 190, 112, 0.14);
+  color: rgba(255, 242, 196, 0.98);
+}
+
+@keyframes characterPickerDrop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.character-forge-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0.75rem;
+}
+
+.character-forge-chip {
+  border: 1px solid rgba(155, 237, 221, 0.22);
+  border-radius: 999px;
+  background: rgba(121, 215, 194, 0.1);
+  color: rgba(224, 250, 245, 0.86);
+  padding: 0.18rem 0.44rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.character-forge-chip--gear {
+  border-color: rgba(248, 219, 138, 0.24);
+  background: rgba(248, 219, 138, 0.1);
+}
+
+.character-forge-stats {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.45rem;
+}
+
+.character-forge-stat {
+  border-radius: 0.6rem;
+  background: rgba(2, 12, 11, 0.3);
+  padding: 0.42rem 0.25rem;
+  text-align: center;
+}
+
+.character-forge-stat span {
+  display: block;
+  color: rgba(207, 222, 218, 0.7);
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.character-forge-stat strong {
+  display: block;
+  color: rgba(245, 255, 252, 0.96);
+  font-size: 0.9rem;
+  line-height: 1.1;
+}
+
+.retro-chat-pane--character-setup {
+  position: relative;
+}
+
+.retro-chat-pane--character-setup::before {
+  content: "";
+  position: absolute;
+  inset: 0.35rem 0.7rem 0.7rem 0.35rem;
+  pointer-events: none;
+  border-radius: 1rem;
+  background:
+    linear-gradient(rgba(202, 255, 243, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(202, 255, 243, 0.035) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: radial-gradient(circle at center, black 0%, transparent 72%);
+}
+
+.retro-chat-pane--character-setup::after {
+  content: "";
+  position: absolute;
+  inset: auto 10% 8% 10%;
+  height: 34%;
+  pointer-events: none;
+  border-radius: 999px;
+  background: radial-gradient(circle at center, rgba(70, 210, 182, 0.18), transparent 70%);
+  filter: blur(18px);
+}
+
+.empty-adventure-stage {
+  position: relative;
+  z-index: 1;
+  width: min(32rem, 82%);
+  padding: 2rem 1.25rem;
+}
+
+.empty-adventure-stage__sigil {
+  position: relative;
+  width: 8.5rem;
+  height: 8.5rem;
+  margin: 0 auto 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(222, 193, 118, 0.34);
+  background:
+    conic-gradient(from 15deg, transparent 0deg, rgba(222, 193, 118, 0.28) 38deg, transparent 72deg, rgba(118, 229, 207, 0.2) 116deg, transparent 180deg, rgba(222, 193, 118, 0.24) 245deg, transparent 360deg),
+    radial-gradient(circle at center, rgba(10, 40, 36, 0.62), rgba(1, 12, 12, 0.14) 62%, transparent 63%);
+  box-shadow:
+    inset 0 0 32px rgba(138, 235, 216, 0.12),
+    0 0 46px rgba(92, 220, 196, 0.18),
+    0 0 70px rgba(222, 193, 118, 0.1);
+}
+
+.empty-adventure-stage__sigil::before,
+.empty-adventure-stage__sigil::after,
+.empty-adventure-stage__sigil span {
+  content: "";
+  position: absolute;
+  inset: 18%;
+  border: 1px solid rgba(229, 255, 249, 0.28);
+  transform: rotate(45deg);
+}
+
+.empty-adventure-stage__sigil::after {
+  inset: 31%;
+  border-color: rgba(222, 193, 118, 0.42);
+  transform: rotate(0deg);
+}
+
+.empty-adventure-stage__sigil span {
+  inset: 42%;
+  border-radius: 999px;
+  border-color: rgba(141, 237, 221, 0.5);
+  transform: none;
+  box-shadow: 0 0 22px rgba(141, 237, 221, 0.35);
+}
+
+.empty-adventure-stage__eyebrow {
+  color: rgba(222, 193, 118, 0.9);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.empty-adventure-stage__title {
+  margin-top: 0.65rem;
+  color: rgba(245, 255, 252, 0.98);
+  font-family: var(--rpg-font-display);
+  font-size: clamp(1.8rem, 4vw, 3.3rem);
+  line-height: 1.05;
+  text-shadow: 0 0 24px rgba(129, 232, 211, 0.2);
+}
+
+.empty-adventure-stage__line {
+  margin: 0.8rem auto 0;
+  max-width: 26rem;
+  color: rgba(220, 235, 231, 0.72);
+  font-size: 0.9rem;
+  line-height: 1.65;
 }
 
 .retro-side-action {


### PR DESCRIPTION
## Summary
- Reworked the login screen copy to present Brain in Cup as a conventional fantasy RPG app, not a consciousness experiment
- Updated the hero messaging, supporting bullets, and call-to-action language to focus on character creation, quests, dice, inventory, and campaign history
- Aligned page and manifest metadata with the new RPG positioning and removed explicit AI framing from the auth surface

## Testing
- `npm run build` passed
- Verified the updated branding text in the auth component and metadata files