### PR TITLE
feat(chat): interactive sidebar, cancel fix, remove placeholders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { normalizePersonalityMode } from './constants/personalityModes';
 import type { PersonalityModeId } from './constants/personalityModes';
 import {
   chooseAutoAvatarId,
-  getAvatarOptionsForRace,
   getAvatarOptionById,
 } from './constants/gameMasterAvatars';
 import { isTestModeEnabled } from './utils/testMode';
@@ -1926,55 +1925,28 @@ function App() {
     );
   }, [conversationId, createCharacter, createConversationWithMode, effectivePersonality, handleSendMessage]);
 
-  const handleCharacterCreationQuickStart = useCallback(async () => {
-    const { calculateFinalStats, getAllRaces, getAllClasses } = await import('./game');
-    const raceOptions = getAllRaces();
-    const classOptions = getAllClasses();
-    if (raceOptions.length === 0 || classOptions.length === 0) {
-      throw new Error('No races or classes are configured for quick start');
-    }
-
-    const selectedRace = raceOptions[Math.floor(Math.random() * raceOptions.length)];
-    const selectedClass = classOptions[Math.floor(Math.random() * classOptions.length)];
-    const raceAvatarOptions = getAvatarOptionsForRace(selectedRace.name);
-    const randomAvatarId = raceAvatarOptions.length > 0
-      ? raceAvatarOptions[Math.floor(Math.random() * raceAvatarOptions.length)].id
-      : chooseAutoAvatarId({
-        name: 'Adventurer',
-        race: selectedRace.name,
-        characterClass: selectedClass.name,
-      });
-    const stats = calculateFinalStats(selectedClass.id, selectedRace.id);
-    const quickStartCharacter: CharacterCreationInput = {
-      name: 'Adventurer',
-      race: selectedRace.name,
-      characterClass: selectedClass.name,
-      avatarId: randomAvatarId,
-      ...stats,
-    };
-
-    if (!conversationId) {
-      const createdConversationId = await createConversationWithMode(effectivePersonality);
-      if (!createdConversationId) {
-        throw new Error('Unable to create chat');
+  const handleCharacterCreationCancel = useCallback(async () => {
+    if (conversationId) {
+      try {
+        if (!isTestModeEnabled()) {
+          await dataClient.models.Conversation.delete({ id: conversationId });
+        }
+        removeStoredConversationAvatar(conversationId);
+      } catch (error) {
+        console.error('Error deleting conversation on cancel:', error);
       }
-      setPendingCharacterDraft(null);
-      setIsNewInteractionPrimed(false);
-      await createCharacter(createdConversationId, quickStartCharacter);
-      await handleSendMessage(
-        `[SYSTEM: Begin the adventure. The player's character is ${quickStartCharacter.name}, a ${quickStartCharacter.race} ${quickStartCharacter.characterClass}. Open with a vivid scene-setting narration that establishes the location, atmosphere, and an immediate hook. Do not wait for the player to speak first.]`,
-        createdConversationId,
-      );
-      return;
     }
+    setConversationId(null);
+    setMessages([]);
+    setInputMessage('');
+    setIsWaitingForResponse(false);
+    setAdventureState(null);
+    setQuestSteps([]);
+    setCharacterState(null);
     setPendingCharacterDraft(null);
-    setIsNewInteractionPrimed(false);
-    await createCharacter(conversationId, quickStartCharacter);
-    await handleSendMessage(
-      `[SYSTEM: Begin the adventure. The player's character is ${quickStartCharacter.name}, a ${quickStartCharacter.race} ${quickStartCharacter.characterClass}. Open with a vivid scene-setting narration that establishes the location, atmosphere, and an immediate hook. Do not wait for the player to speak first.]`,
-      conversationId,
-    );
-  }, [conversationId, createCharacter, createConversationWithMode, effectivePersonality, handleSendMessage]);
+    setShowCharacterCreation(false);
+    setConversationListRefreshKey((prev) => prev + 1);
+  }, [conversationId]);
 
   const isGameMasterMode = effectivePersonality === 'game_master';
   const appThemeClass = isGameMasterMode ? 'retro-rpg-ui--gm' : 'retro-rpg-ui--brain';
@@ -2162,22 +2134,6 @@ function App() {
         <aside className="retro-shell-left">
           <div className="retro-left-container retro-left-panel-icon-only relative flex h-full flex-col overflow-visible px-3">
                 <div className="flex h-full flex-col items-center gap-5 py-4">
-                  <div className="flex w-full flex-col items-center gap-2 shrink-0">
-                    <button
-                      type="button"
-                      onClick={handleNewConversation}
-                      disabled={isWaitingForResponse || isSelectingConversation}
-                      className="retro-icon-button retro-tooltip-trigger h-10 w-10 rounded-xl border border-brand-surface-border/50 bg-brand-surface-secondary/60 text-brand-text-primary flex items-center justify-center transition-all duration-200 hover:border-brand-surface-border/70 hover:bg-brand-surface-secondary/75 disabled:cursor-not-allowed disabled:opacity-45"
-                      aria-label="Start new chat"
-                      title="New chat"
-                      data-tooltip="New chat"
-                      data-tooltip-position="right"
-                    >
-                      <img src="/addChat.svg" alt="" aria-hidden="true" className="h-5 w-5 object-contain brightness-0 invert" />
-                    </button>
-                    {/* Mode toggle buttons removed - mode is now hardcoded to game_master */}
-                  </div>
-
                   <ConversationSidebarIcons
                     onSelectConversation={handleSelectConversation}
                     onSelectBrain={() => {
@@ -2186,8 +2142,10 @@ function App() {
                         handleSelectConversation(brainConversationId);
                       }
                     }}
+                    onNewConversation={handleNewConversation}
                     activeConversationId={conversationId === brainConversationId ? 'brain' : conversationId}
                     refreshKey={conversationListRefreshKey}
+                    isDisabled={isWaitingForResponse || isSelectingConversation}
                   />
 
                   <div ref={profileMenuRef} className="relative z-40">
@@ -2548,7 +2506,7 @@ function App() {
                           inline
                           embedded
                           onComplete={handleCharacterCreationComplete}
-                          onCancel={handleCharacterCreationQuickStart}
+                          onCancel={handleCharacterCreationCancel}
                         />
                       </div>
                     ) : (
@@ -2655,18 +2613,6 @@ function App() {
             </div>
 
             <div>
-              <button
-                type="button"
-                onClick={handleNewConversation}
-                disabled={isWaitingForResponse || isSelectingConversation}
-                className="mb-2.5 w-full flex items-center gap-3 rounded-xl border border-brand-surface-border/45 bg-brand-bg-secondary/65 px-2.5 py-2 text-left transition-all duration-200 hover:border-brand-surface-border/65 hover:bg-brand-bg-tertiary/55 disabled:cursor-not-allowed disabled:opacity-45"
-                aria-label="Start new chat"
-              >
-                <span className="flex h-9 w-9 items-center justify-center rounded-full border border-brand-surface-border/60 bg-brand-surface-secondary/45 text-brand-text-primary">
-                  <img src="/addChat.svg" alt="" aria-hidden="true" className="h-4.5 w-4.5 object-contain brightness-0 invert" />
-                </span>
-                <span className="text-sm font-medium text-brand-text-primary">New Chat</span>
-              </button>
               {/* Mode toggle buttons removed - mode is now hardcoded to game_master */}
             </div>
           </div>
@@ -2864,7 +2810,7 @@ function App() {
                   <CharacterCreation
                     inline
                     onComplete={handleCharacterCreationComplete}
-                    onCancel={handleCharacterCreationQuickStart}
+                    onCancel={handleCharacterCreationCancel}
                   />
                 </div>
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -435,25 +435,27 @@ function App() {
   const characterCreationLock = useRef(false);
   const adventureFetchLock = useRef<string | null>(null);
   
-  // Helper to get character display data with fallbacks
+  // Helper to get character display data — returns null when no character exists
   const getCharacterData = useCallback(() => {
+    if (!characterState) return null;
+    
     const stats = {
-      strength: characterState?.strength || 10,
-      dexterity: characterState?.dexterity || 12,
-      constitution: characterState?.constitution || 14,
-      intelligence: characterState?.intelligence || 16,
-      wisdom: characterState?.wisdom || 13,
-      charisma: characterState?.charisma || 11,
+      strength: characterState.strength ?? 10,
+      dexterity: characterState.dexterity ?? 10,
+      constitution: characterState.constitution ?? 10,
+      intelligence: characterState.intelligence ?? 10,
+      wisdom: characterState.wisdom ?? 10,
+      charisma: characterState.charisma ?? 10,
     };
     
     const hp = {
-      current: characterState?.currentHP || 12,
-      max: characterState?.maxHP || 12,
-      percentage: ((characterState?.currentHP || 12) / (characterState?.maxHP || 12)) * 100,
+      current: characterState.currentHP ?? 0,
+      max: characterState.maxHP ?? 0,
+      percentage: characterState.maxHP ? ((characterState.currentHP ?? 0) / characterState.maxHP) * 100 : 0,
     };
     
-    const inventory = parseInventoryItems(characterState?.inventory);
-    const avatarId = getAvatarOptionById(characterState?.avatarId ?? '')?.id
+    const inventory = parseInventoryItems(characterState.inventory);
+    const avatarId = getAvatarOptionById(characterState.avatarId ?? '')?.id
       ?? getAvatarOptionById(getStoredConversationAvatarId(conversationId))?.id
       ?? '';
     const avatarOption = avatarId ? getAvatarOptionById(avatarId) : undefined;
@@ -463,10 +465,10 @@ function App() {
     const avatarSrcMedium = avatarOption?.srcMedium ?? '';
     
     return {
-      name: characterState?.name || 'Adventurer',
-      race: characterState?.race || 'Wanderer',
-      characterClass: characterState?.characterClass || 'Wanderer',
-      level: characterState?.level || 1,
+      name: characterState.name ?? '',
+      race: characterState.race ?? '',
+      characterClass: characterState.characterClass ?? '',
+      level: characterState.level ?? 1,
       avatarId,
       avatarSrc,
       avatarSrcWebp,
@@ -2008,7 +2010,7 @@ function App() {
 
     if (isValid(adventureState?.currentLocation)) return adventureState!.currentLocation!;
     if (isValid(adventureState?.lastLocation)) return adventureState!.lastLocation!;
-    return 'The Shrouded Vale';
+    return undefined;
   }, [adventureState?.currentLocation, adventureState?.lastLocation]);
   
   const currentAct = useMemo(() => {
@@ -2522,7 +2524,7 @@ function App() {
                             diceRollLog: playerState.diceRollLog as any ?? undefined,
                             pendingDiceRoll: playerState.pendingDiceRoll ?? undefined,
                           } : undefined}
-                          character={{
+                          character={characterDisplay ? {
                             name: characterDisplay.name,
                             level: characterDisplay.level,
                             currentHP: characterDisplay.hp.current,
@@ -2530,7 +2532,7 @@ function App() {
                             stats: characterDisplay.stats,
                             avatarSrc: characterDisplay.avatarSrc,
                             avatarSrcWebp: characterDisplay.avatarSrcWebp,
-                          }}
+                          } : undefined}
                           currentLocation={currentLocation}
                           activeQuests={[]}
                           timelineEntries={messages
@@ -2547,6 +2549,7 @@ function App() {
                         />
 
                         {/* Inventory */}
+                        {characterDisplay && (
                         <div className="retro-right-section retro-right-section--inventory">
                           <InventoryManager
                             inventory={characterDisplay.inventory}
@@ -2554,6 +2557,7 @@ function App() {
                             isUpdating={false}
                           />
                         </div>
+                        )}
 
                         <button
                           type="button"
@@ -2619,7 +2623,7 @@ function App() {
         </nav>
 
         {/* Floating Expandable Header Bars - Side by Side - Only for Game Master mode */}
-        {effectivePersonality === 'game_master' && characterState && !isGameMasterContentLoading && (
+        {effectivePersonality === 'game_master' && characterState && characterDisplay && !isGameMasterContentLoading && (
           <div className="retro-mobile-bars lg:hidden sticky top-0 z-40 pt-safe">
             <div className="flex gap-2 mx-4 mt-4 items-start">
               {/* First Bar - Quest Log */}
@@ -2696,7 +2700,7 @@ function App() {
                             <source srcSet={characterDisplay.avatarSrcWebp} type="image/webp" />
                             <img
                               src={characterDisplay.avatarSrc}
-                              alt={`${characterDisplay.name || 'Adventurer'} avatar`}
+                              alt={`${characterDisplay.name} avatar`}
                               loading="lazy"
                               decoding="async"
                               className="retro-character-avatar retro-character-avatar--compact w-10 h-10 rounded-lg object-cover object-center flex-shrink-0"
@@ -2706,7 +2710,7 @@ function App() {
                       ) : null}
                       <div className="retro-character-meta retro-character-meta--compact min-w-0 flex-1">
                         <p className="text-xs text-brand-text-muted uppercase tracking-wider">Character</p>
-                        <p className="text-sm text-brand-text-primary font-medium truncate">{characterDisplay.name || 'Adventurer'}</p>
+                        <p className="text-sm text-brand-text-primary font-medium truncate">{characterDisplay.name}</p>
                       </div>
                     </div>
                     <svg 
@@ -2722,8 +2726,8 @@ function App() {
                   </button>
 
                   {/* Expanded Character Sheet Content */}
-                  {mobileCharSheetExpanded && adventureState && !isGameMasterContentLoading && characterState && (() => {
-                    const charData = getCharacterData();
+                  {mobileCharSheetExpanded && adventureState && !isGameMasterContentLoading && characterState && characterDisplay && (() => {
+                    const charData = characterDisplay;
                     return (
                       <div className="px-4 pb-4 space-y-3 animate-slide-up border-t border-brand-surface-border/30 pt-4">
                         {/* Stats */}

--- a/src/components/CharacterCreation.tsx
+++ b/src/components/CharacterCreation.tsx
@@ -345,7 +345,7 @@ export default function CharacterCreation({ onComplete, onCancel, inline = false
               className="flex-1 rounded-xl border border-brand-surface-border/45 bg-brand-surface-elevated/55 px-3 py-1.5 text-sm font-medium text-brand-text-secondary backdrop-blur-md transition-all duration-200 hover:border-brand-surface-border/70 hover:bg-brand-surface-elevated/70 disabled:cursor-not-allowed disabled:opacity-60"
               disabled={isSubmitting}
             >
-              Quick
+              Cancel
             </button>
           )}
           <button

--- a/src/components/ContextWindowPanel.tsx
+++ b/src/components/ContextWindowPanel.tsx
@@ -102,8 +102,41 @@ function ContextWindowPanel({
         )}
 
         {activePanel === 'character' && !character && (
-          <div className="p-4 text-center text-brand-text-muted text-xs">
-            No character yet
+          <div className="p-4 space-y-3 animate-pulse">
+            {/* Avatar + name skeleton */}
+            <div className="flex items-center gap-3">
+              <div className="h-14 w-14 rounded-xl bg-brand-surface-hover" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 bg-brand-surface-hover rounded w-2/3" />
+                <div className="h-2 bg-brand-surface-hover rounded w-1/3" />
+              </div>
+            </div>
+            {/* HP bar skeleton */}
+            <div className="space-y-1.5">
+              <div className="flex justify-between">
+                <div className="h-2 bg-brand-surface-hover rounded w-6" />
+                <div className="h-2 bg-brand-surface-hover rounded w-10" />
+              </div>
+              <div className="h-1.5 bg-brand-surface-hover rounded-full w-full" />
+            </div>
+            {/* XP bar skeleton */}
+            <div className="space-y-1.5">
+              <div className="flex justify-between">
+                <div className="h-2 bg-brand-surface-hover rounded w-6" />
+                <div className="h-2 bg-brand-surface-hover rounded w-10" />
+              </div>
+              <div className="h-1.5 bg-brand-surface-hover rounded-full w-full" />
+            </div>
+            {/* Stats grid skeleton */}
+            <div className="grid grid-cols-3 gap-1.5">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="bg-brand-surface-hover rounded-lg p-1.5 space-y-1">
+                  <div className="h-1.5 bg-brand-surface-dark/50 rounded w-6 mx-auto" />
+                  <div className="h-3 bg-brand-surface-dark/50 rounded w-4 mx-auto" />
+                  <div className="h-1.5 bg-brand-surface-dark/50 rounded w-3 mx-auto" />
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/src/components/ContextWindowPanel.tsx
+++ b/src/components/ContextWindowPanel.tsx
@@ -85,20 +85,26 @@ function ContextWindowPanel({
 
       {/* Panel content with opacity transition */}
       <div className="flex-1 transition-opacity duration-200">
-        {activePanel === 'character' && (
+        {activePanel === 'character' && character && (
           <CharacterSheetPanel
-            name={character?.name}
-            level={character?.level ?? playerState?.currentLevel}
-            currentHP={character?.currentHP}
-            maxHP={character?.maxHP}
+            name={character.name}
+            level={character.level ?? playerState?.currentLevel}
+            currentHP={character.currentHP}
+            maxHP={character.maxHP}
             currentXP={playerState?.currentXP}
             xpToNextLevel={playerState?.xpToNextLevel}
-            stats={character?.stats as CharacterSheetPanelProps['stats']}
+            stats={character.stats as CharacterSheetPanelProps['stats']}
             currentLocation={currentLocation ?? playerState?.lastKnownLocation}
-            avatarSrc={character?.avatarSrc}
-            avatarSrcWebp={character?.avatarSrcWebp}
+            avatarSrc={character.avatarSrc}
+            avatarSrcWebp={character.avatarSrcWebp}
             levelUpAnimating={levelUpAnimating}
           />
+        )}
+
+        {activePanel === 'character' && !character && (
+          <div className="p-4 text-center text-brand-text-muted text-xs">
+            No character yet
+          </div>
         )}
 
         {activePanel === 'quests' && (

--- a/src/components/ConversationSidebarIcons.tsx
+++ b/src/components/ConversationSidebarIcons.tsx
@@ -44,18 +44,24 @@ const writeConversationCache = (metadata: ConversationMetadata[]) => {
   } catch { /* ignore */ }
 };
 
+const CHAT_LIMIT = 3;
+
 interface ConversationSidebarIconsProps {
   onSelectConversation: (conversationId: string) => void;
   onSelectBrain: () => void;
+  onNewConversation: () => void;
   activeConversationId: string | null;
   refreshKey: number;
+  isDisabled: boolean;
 }
 
 export default function ConversationSidebarIcons({
   onSelectConversation,
   onSelectBrain,
+  onNewConversation,
   activeConversationId,
   refreshKey,
+  isDisabled,
 }: ConversationSidebarIconsProps) {
   const [icons, setIcons] = useState<Array<{ id: string; avatarSrc: string; avatarSrcWebp: string; title: string; preview: string }>>([]);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -204,7 +210,7 @@ export default function ConversationSidebarIcons({
 
       {/* GM conversation icons - scrollable area */}
       <div className="flex w-full flex-col items-center gap-2 overflow-y-auto flex-1 min-h-0 py-2">
-        {icons.map((icon) => (
+        {icons.filter(icon => icon.avatarSrc).map((icon) => (
         <div key={icon.id} className="relative">
           <button
             type="button"
@@ -224,22 +230,16 @@ export default function ConversationSidebarIcons({
                 : 'border-brand-surface-border/40 bg-brand-surface-secondary/50 hover:border-brand-surface-border/60'
             }`}
           >
-            {icon.avatarSrc ? (
-              <picture>
-                <source srcSet={icon.avatarSrcWebp} type="image/webp" />
-                <img
-                  src={icon.avatarSrc}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  className="h-full w-full object-cover object-center"
-                />
-              </picture>
-            ) : (
-              <span className="text-xs font-semibold text-brand-text-muted uppercase">
-                {icon.title.charAt(0)}
-              </span>
-            )}
+            <picture>
+              <source srcSet={icon.avatarSrcWebp} type="image/webp" />
+              <img
+                src={icon.avatarSrc}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="h-full w-full object-cover object-center"
+              />
+            </picture>
           </button>
 
           {hoveredId === icon.id && (
@@ -253,6 +253,24 @@ export default function ConversationSidebarIcons({
           )}
         </div>
       ))}
+
+        {/* New chat plus button - at bottom, only visible when under chat limit */}
+        {icons.filter(icon => icon.avatarSrc).length < CHAT_LIMIT && (
+          <button
+            type="button"
+            onClick={onNewConversation}
+            disabled={isDisabled}
+            className="plus-button h-10 w-10 rounded-xl border border-brand-surface-border/50 bg-brand-surface-secondary/60 text-brand-text-primary flex items-center justify-center transition-all duration-200 hover:border-brand-surface-border/70 hover:bg-brand-surface-secondary/75 disabled:cursor-not-allowed disabled:opacity-45"
+            aria-label="Start new chat"
+            data-tooltip="New chat"
+            data-tooltip-position="right"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="10" y1="4" x2="10" y2="16" />
+              <line x1="4" y1="10" x2="16" y2="10" />
+            </svg>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/ConversationSidebarIcons.tsx
+++ b/src/components/ConversationSidebarIcons.tsx
@@ -80,7 +80,7 @@ export default function ConversationSidebarIcons({
       const sorted = (data || []).sort((a, b) => {
         const aDate = new Date(a.updatedAt || a.createdAt || 0).getTime();
         const bDate = new Date(b.updatedAt || b.createdAt || 0).getTime();
-        return bDate - aDate;
+        return aDate - bDate;
       });
 
       // Filter out Brain conversation - only show GM conversations

--- a/src/components/context/CharacterSheetPanel.tsx
+++ b/src/components/context/CharacterSheetPanel.tsx
@@ -34,20 +34,24 @@ function statModifier(value: number): string {
 }
 
 function CharacterSheetPanel({
-  name = 'Adventurer',
-  level = 1,
-  currentHP = 10,
-  maxHP = 10,
-  currentXP = 0,
-  xpToNextLevel = 100,
+  name,
+  level,
+  currentHP,
+  maxHP,
+  currentXP,
+  xpToNextLevel,
   currentLocation,
   avatarSrc,
   avatarSrcWebp,
-  stats = {},
+  stats,
   levelUpAnimating = false,
 }: CharacterSheetPanelProps) {
-  const hpPercent = maxHP > 0 ? Math.min(100, (currentHP / maxHP) * 100) : 0;
-  const xpPercent = xpToNextLevel > 0 ? Math.min(100, (currentXP / xpToNextLevel) * 100) : 0;
+  const resolvedHP = currentHP ?? 0;
+  const resolvedMaxHP = maxHP ?? 0;
+  const hpPercent = resolvedMaxHP > 0 ? Math.min(100, (resolvedHP / resolvedMaxHP) * 100) : 0;
+  const resolvedXP = currentXP ?? 0;
+  const resolvedXPMax = xpToNextLevel ?? 100;
+  const xpPercent = resolvedXPMax > 0 ? Math.min(100, (resolvedXP / resolvedXPMax) * 100) : 0;
   const hpBarColor = hpPercent <= 25 ? 'bg-brand-status-error' : 'bg-green-500';
 
   return (
@@ -89,7 +93,7 @@ function CharacterSheetPanel({
       <div>
         <div className="flex justify-between text-[10px] text-brand-text-muted mb-1">
           <span>HP</span>
-          <span>{currentHP} / {maxHP}</span>
+          <span>{resolvedHP} / {resolvedMaxHP}</span>
         </div>
         <div className="w-full bg-brand-surface-border rounded-full h-1.5">
           <div
@@ -103,7 +107,7 @@ function CharacterSheetPanel({
       <div>
         <div className="flex justify-between text-[10px] text-brand-text-muted mb-1">
           <span>XP</span>
-          <span>{currentXP} / {xpToNextLevel}</span>
+          <span>{resolvedXP} / {resolvedXPMax}</span>
         </div>
         <div className="w-full bg-brand-surface-border rounded-full h-1.5">
           <div
@@ -116,7 +120,7 @@ function CharacterSheetPanel({
       {/* Stats grid */}
       <div className="grid grid-cols-3 gap-1.5">
         {STAT_LABELS.map(([key, label]) => {
-          const value = stats[key] ?? 10;
+          const value = stats?.[key] ?? 0;
           return (
             <div
               key={key}

--- a/src/components/context/WorldMapPanel.tsx
+++ b/src/components/context/WorldMapPanel.tsx
@@ -13,7 +13,7 @@ interface WorldMapPanelProps {
 }
 
 function WorldMapPanel({
-  currentLocation = 'The Shrouded Vale',
+  currentLocation,
   visitedLocations = [],
   connectedAreas = [],
   characterLevel = 1,

--- a/src/index.css
+++ b/src/index.css
@@ -1444,6 +1444,57 @@ textarea.w-full:focus {
   -ms-overflow-style: none;
 }
 
+/* Plus button press animation */
+.plus-button {
+  position: relative;
+  overflow: hidden;
+}
+
+.plus-button::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(139, 92, 246, 0.4) 0%, transparent 70%);
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.plus-button:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.plus-button:active {
+  transform: scale(0.92);
+  transition: transform 0.1s ease;
+}
+
+.plus-button:active::before {
+  opacity: 1;
+  transform: scale(1.5);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.plus-button:focus-visible {
+  outline: 2px solid rgba(139, 92, 246, 0.6);
+  outline-offset: 2px;
+}
+
+.plus-button svg {
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.plus-button:hover svg {
+  transform: rotate(90deg) scale(1.1);
+}
+
+.plus-button:active svg {
+  transform: rotate(180deg) scale(0.95);
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 @media (max-width: 1024px) {
   .retro-center-split {
     display: block;


### PR DESCRIPTION
## Changes

### Interactive plus button for new chats
- Removed desktop and mobile "New Chat" buttons
- Added interactive `+` button at bottom of character list with press animation (glow + rotate + scale)
- Chat limit of 3 conversations (excluding Brain icon)
- Button hides when at limit
- Brain chat always pinned to top

### Character sidebar improvements
- Removed letter fallback placeholder ("Q") for conversations without avatars
- Only shows conversations that have a confirmed character avatar
- Conversations sorted oldest-first so new ones appear at bottom

### Cancel button replaces Quick button
- Renamed "Quick" to "Cancel" in character creation
- Cancel now properly deletes the orphaned conversation from the database
- All state reset on cancel

### No more placeholder data
- `getCharacterData()` returns `null` when no character exists
- `CharacterSheetPanel` removed all default prop values
- `WorldMapPanel` removed default "The Shrouded Vale" location
- Right panel shows animated loading skeleton instead of fake data
- Mobile bars hidden when no character exists