### PR TITLE
refactor(backend): replace AgentCore containers with direct Bedrock invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.agentcore
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ For technical implementation details and architecture diagrams, see [Backend Arc
 ### Prerequisites
 
 - Node.js 18+ and npm
-- Docker (for local development of the AI runtime)
 
 ### Quick Start
 
@@ -82,6 +81,9 @@ The app works best when installed on mobile devices:
 - `npm run build` - Build for production
 - `npm run preview` - Preview production build locally
 - `npm run lint` - Run code quality checks
+- `npm run deploy:sandbox` - Deploy backend infrastructure (no Docker needed)
+- `npm run deploy:all` - Full deployment
+- `npm run deploy:container` - Deploy using AgentCore container mode (requires Docker)
 
 ### Troubleshooting
 

--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -2,109 +2,67 @@
 
 This directory contains the Amazon Bedrock AgentCore runtime implementation for the Brain In Cup agent.
 
+## Current Status: Direct Code Mode
+
+The Lambda function now calls Bedrock directly, eliminating the need for a separate
+AgentCore container runtime. This directory is **preserved intact** for easy fallback.
+
 ## Structure
 ```
 agent-runtime/
 ├── app/
 │   ├── __init__.py          # Package marker
-│   ├── main.py              # AgentCore entrypoint handler
+│   ├── main.py              # AgentCore entrypoint handler (FastAPI)
 │   └── requirements.txt     # Runtime dependencies
-├── scripts/
-│   └── start.sh             # Optional bootstrap script
 ├── Dockerfile               # Container image definition
 └── README.md               # This file
 ```
 
-## Building and Updating the Image
+## Switching to Container Mode
 
-After making changes to the agent code, rebuild and push the container:
+To restore the original AgentCore container deployment:
 
-**Quick update:**
-```bash
-./scripts/update-agent-image.sh
-```
+1. **Revert `amplify/functions/brain/app/main.py`:**
+   - Replace `invoke_bedrock()` calls with `invoke_agentcore()` calls
+   - Restore the `invoke_agentcore` function (see `main.py.__init__` for reference)
 
-**Manual steps** (if you prefer):
+2. **Uncomment the AgentCore runtime block in `amplify/backend.ts`:**
+   - Search for "AgentCore" — there's a comment block with instructions
+   - This re-creates the `AWS::BedrockAgentCore::Runtime` resource
+
+3. **Build and push the container:**
    ```bash
    export AWS_REGION=us-east-1
    export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
    export REPO=brain-agent
-   ```
 
-2. **Create ECR repository** (if not exists):
-   ```bash
+   # Create ECR repository (if not exists)
    aws ecr create-repository --repository-name $REPO --region $AWS_REGION || true
-   ```
 
-3. **Login to ECR**:
-   ```bash
+   # Login to ECR
    aws ecr get-login-password --region "$AWS_REGION" \
      | docker login --username AWS --password-stdin "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
-   ```
 
-4. **Build the image**:
-   ```bash
+   # Build the image
    docker build -t $REPO:latest ./agent-runtime
-   ```
 
-5. **Tag and push**:
-   ```bash
+   # Tag and push
    docker tag $REPO:latest "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
    docker push "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
    ```
 
-6. **Record the URI**:
+4. **Or use the npm script:**
    ```bash
-   export AGENTCORE_CONTAINER_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
-   echo $AGENTCORE_CONTAINER_URI
+   npm run deploy:container
    ```
 
 ## Testing Locally
 
-Run the container locally to test before pushing:
-```bash
-docker run --rm -p 8080:8080 \
-  -e LOG_LEVEL=DEBUG \
-  -e BEDROCK_MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0 \
-  $REPO:latest
-```
-
-Or test the handler directly:
+Run the handler directly (works in either mode):
 ```bash
 cd agent-runtime
 python -m app.main
 ```
 
-## Deploying to Amplify
-
-After pushing the image to ECR:
-```bash
-export AGENTCORE_CONTAINER_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
-export AGENTCORE_RUNTIME_NAME=BrainInCupRuntime
-export AGENTCORE_NETWORK_MODE=PUBLIC
-
-cd ..
-npm run sandbox
-```
-
-The Amplify/CDK stack will provision the `AWS::BedrockAgentCore::Runtime` and inject its ARN into the Lambda automatically.
-
-## Next Steps
-
-1. **Implement real model invocation** in `app/main.py`:
-   - Replace the stub response with actual Bedrock runtime API calls
-   - Use `boto3.client('bedrock-runtime').invoke_model()` to call Claude/Sonnet
-   - Parse the model response and format it per the JSON schema
-
-2. **Add tool support** (optional):
-   - Register tools via AgentCore Gateway
-   - Implement tool handlers in the runtime
-
-3. **Enable memory** (optional):
-   - Use AgentCore Memory API to persist conversation context
-   - Remove ad-hoc context stitching from Lambda
-
 ## References
-- [AWS::BedrockAgentCore::Runtime CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-bedrockagentcore-runtime.html)
-- [AgentCore Runtime Getting Started](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html)
-- [AgentCore Starter Toolkit](https://aws.github.io/bedrock-agentcore-starter-toolkit/)
+- [AWS::BedrockAgentCore::Runtime CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-bedrockagentcore-runtime.html)

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -2,11 +2,11 @@ import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { brain } from './functions/brain/resource';
-import { PolicyStatement, Effect, ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { EventSourceMapping, StartingPosition } from 'aws-cdk-lib/aws-lambda';
 import { FunctionUrlAuthType, HttpMethod } from 'aws-cdk-lib/aws-lambda';
 import { StreamViewType } from 'aws-cdk-lib/aws-dynamodb';
-import { Tags, CfnResource, CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
+import { Tags, CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -192,12 +192,6 @@ new CfnOutput(stack, 'ImageBucketName', {
 // ─── Observability Infrastructure ────────────────────────────────────────────
 const obsConfig = buildObservabilityConfig(getAgentCoreConfig);
 
-const sanitizeRuntimeName = (value: string) => {
-  const stripped = value.replace(/[^A-Za-z0-9_]/g, '') || 'BrainAgentRuntime';
-  const prefixed = /^[A-Za-z]/.test(stripped) ? stripped : `Brain${stripped}`;
-  return prefixed.slice(0, 48);
-};
-
 // Add tags to all resources in the stack
 Tags.of(stack).add('Project', 'BrainInCup');
 Tags.of(stack).add('Environment', stack.stackName.includes('sandbox') ? 'development' : 'production');
@@ -236,109 +230,16 @@ brainLambda.addEnvironment('ADVENTURE_TABLE_NAME', adventureTable.tableName);
 brainLambda.addEnvironment('APPSYNC_API_URL', backend.data.resources.cfnResources.cfnGraphqlApi.attrGraphQlUrl);
 brainLambda.addEnvironment('AWS_REGION_NAME', stack.region);
 
-const agentcoreContainerUri = getAgentCoreConfig('AGENTCORE_CONTAINER_URI');
-// Generate unique runtime name based on stack name and account to avoid conflicts
-const baseRuntimeName = sanitizeRuntimeName(stack.stackName);
-const defaultRuntimeName = `${baseRuntimeName}-${stack.account.slice(-4)}`;
-const requestedRuntimeName = getAgentCoreConfig('AGENTCORE_RUNTIME_NAME') ?? defaultRuntimeName;
-let agentcoreRuntimeArn = getAgentCoreConfig('AGENTCORE_RUNTIME_ARN');
+// Add Bedrock model ID env var for direct invocation
+brainLambda.addEnvironment('BEDROCK_MODEL_ID', getAgentCoreConfig('BEDROCK_MODEL_ID') ?? 'anthropic.claude-3-sonnet-20240229-v1:0');
 
-// If no ARN is provided, require container URI to create runtime
-if (!agentcoreRuntimeArn) {
-  if (!agentcoreContainerUri) {
-    throw new Error(
-      'AgentCore runtime is required. Please provide either:\n' +
-      '  - AGENTCORE_RUNTIME_ARN (existing runtime ARN)\n' +
-      '  - AGENTCORE_CONTAINER_URI (to create new runtime)\n' +
-      'See docs/archive/AGENTCORE_RUNTIME_SETUP.md for setup instructions.'
-    );
-  }
-
-  // Create the runtime since ARN wasn't provided
-  const agentcoreRuntimeRole = new Role(stack, 'AgentCoreRuntimeRole', {
-    assumedBy: new ServicePrincipal('bedrock-agentcore.amazonaws.com'),
-    description: 'Execution role for Amazon Bedrock AgentCore runtime',
-  });
-  agentcoreRuntimeRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonBedrockFullAccess'));
-  agentcoreRuntimeRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryReadOnly'));
-  
-  // Add CloudWatch Logs permissions for runtime logging
-  agentcoreRuntimeRole.addToPolicy(new PolicyStatement({
-    actions: [
-      'logs:CreateLogGroup',
-      'logs:CreateLogStream',
-      'logs:PutLogEvents',
-    ],
-    resources: [
-      `arn:aws:logs:${stack.region}:${stack.account}:log-group:/aws/bedrock-agentcore/runtimes/*`,
-    ],
-    effect: Effect.ALLOW,
-  }));
-
-  const runtimeResource = new CfnResource(stack, 'AgentCoreRuntime', {
-    type: 'AWS::BedrockAgentCore::Runtime',
-    properties: {
-      AgentRuntimeName: sanitizeRuntimeName(requestedRuntimeName),
-      AgentRuntimeArtifact: {
-        ContainerConfiguration: {
-          ContainerUri: agentcoreContainerUri,
-        },
-      },
-      NetworkConfiguration: {
-        NetworkMode: getAgentCoreConfig('AGENTCORE_NETWORK_MODE') ?? 'PUBLIC',
-      },
-      EnvironmentVariables: {
-        LOG_LEVEL: getAgentCoreConfig('AGENTCORE_RUNTIME_LOG_LEVEL') ?? 'INFO',
-        AWS_REGION: stack.region,
-        OTEL_SERVICE_NAME: getAgentCoreConfig('OTEL_SERVICE_NAME') ?? 'brain-in-cup-agentcore-runtime',
-        OTEL_PROPAGATORS: getAgentCoreConfig('OTEL_PROPAGATORS') ?? 'xray,tracecontext,baggage',
-        // AgentCore OTEL observability env vars (Requirement 4.2)
-        AGENT_OBSERVABILITY_ENABLED: obsConfig.agentcoreEnabled ? 'true' : 'false',
-        OTEL_PYTHON_DISTRO: 'aws_distro',
-        OTEL_PYTHON_CONFIGURATOR: 'aws_configurator',
-        OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
-        OTEL_RESOURCE_ATTRIBUTES: 'service.name=brain-in-cup-agentcore-runtime',
-      },
-      RoleArn: agentcoreRuntimeRole.roleArn,
-      Description: 'Amazon Bedrock AgentCore runtime managed by Amplify Gen2 backend',
-      Tags: {
-        Project: 'BrainInCup',
-        ManagedBy: 'Amplify',
-      },
-    },
-  });
-
-  agentcoreRuntimeArn = runtimeResource.getAtt('AgentRuntimeArn').toString();
-
-  new CfnOutput(stack, 'AgentCoreRuntimeArn', {
-    value: agentcoreRuntimeArn,
-    description: 'ARN of the provisioned Amazon Bedrock AgentCore runtime',
-  });
-}
-
-// Now agentcoreRuntimeArn is guaranteed to be set
-brainLambda.addEnvironment('AGENTCORE_RUNTIME_ARN', agentcoreRuntimeArn);
-brainLambda.addEnvironment('AGENTCORE_TRACE_ENABLED', getAgentCoreConfig('AGENTCORE_TRACE_ENABLED') ?? 'true');
-brainLambda.addEnvironment('AGENTCORE_TRACE_SAMPLE_RATE', getAgentCoreConfig('AGENTCORE_TRACE_SAMPLE_RATE') ?? '1.0');
-const agentcoreMemoryId = getAgentCoreConfig('AGENTCORE_MEMORY_ID');
-if (agentcoreMemoryId) {
-  brainLambda.addEnvironment('AGENTCORE_MEMORY_ID', agentcoreMemoryId);
-}
-const agentcoreMemorySemanticStrategyId = getAgentCoreConfig('AGENTCORE_MEMORY_SEMANTIC_STRATEGY_ID');
-if (agentcoreMemorySemanticStrategyId) {
-  brainLambda.addEnvironment('AGENTCORE_MEMORY_SEMANTIC_STRATEGY_ID', agentcoreMemorySemanticStrategyId);
-}
-const agentcoreMemoryStrategyId = getAgentCoreConfig('AGENTCORE_MEMORY_STRATEGY_ID');
-if (agentcoreMemoryStrategyId) {
-  brainLambda.addEnvironment('AGENTCORE_MEMORY_STRATEGY_ID', agentcoreMemoryStrategyId);
-}
-const agentcoreMemoryCharacterStrategyId = getAgentCoreConfig('AGENTCORE_MEMORY_CHARACTER_STRATEGY_ID');
-if (agentcoreMemoryCharacterStrategyId) {
-  brainLambda.addEnvironment('AGENTCORE_MEMORY_CHARACTER_STRATEGY_ID', agentcoreMemoryCharacterStrategyId);
-}
-const agentcoreMemoryResource = agentcoreMemoryId
-  ? `arn:aws:bedrock-agentcore:${stack.region}:${stack.account}:memory/${agentcoreMemoryId}`
-  : '*';
+// Note: Previously this code created an AWS::BedrockAgentCore::Runtime with a
+// container image. The Lambda now calls Bedrock directly, eliminating the
+// container hop. The agent-runtime/ directory, Dockerfile, and related
+// resources are preserved for easy fallback.
+//
+// To switch back to container mode, uncomment the AgentCore runtime block
+// (see agent-runtime/README.md for instructions).
 
 // Note: Layer is already defined in amplify/functions/brain/resource.ts
 
@@ -349,21 +250,8 @@ new EventSourceMapping(stack, 'BrainMessageMapping', {
 });
 
 brainLambda.addToRolePolicy(new PolicyStatement({
-  actions: ['bedrock-agentcore:InvokeAgentRuntime', 'bedrock-agentcore:InvokeAgentRuntimeForUser'],
-  resources: agentcoreRuntimeArn ? [
-    agentcoreRuntimeArn,
-    `${agentcoreRuntimeArn}/*`,
-  ] : ['*'],
-  effect: Effect.ALLOW,
-}));
-
-brainLambda.addToRolePolicy(new PolicyStatement({
-  actions: [
-    'bedrock-agentcore:CreateEvent',
-    'bedrock-agentcore:RetrieveMemoryRecords',
-    'bedrock-agentcore:BatchCreateMemoryRecords',
-  ],
-  resources: [agentcoreMemoryResource],
+  actions: ['bedrock:InvokeModel'],
+  resources: [`arn:aws:bedrock:${stack.region}::foundation-model/*`],
   effect: Effect.ALLOW,
 }));
 
@@ -539,22 +427,6 @@ new cr.AwsCustomResource(stack, 'TransactionSearchResourcePolicy', {
 
 // ─── CloudWatch Alarms ────────────────────────────────────────────────────────
 
-// Alarm: InvocationErrors > 5 in 5 minutes (bedrock-agentcore namespace)
-const invocationErrorsAlarm = new aws_cloudwatch.Alarm(stack, 'BedrockAgentCoreInvocationErrorsAlarm', {
-  alarmName: `BrainInCup-${stack.stackName}-InvocationErrors`,
-  alarmDescription: 'AgentCore invocation error rate exceeded threshold',
-  metric: new aws_cloudwatch.Metric({
-    namespace: 'bedrock-agentcore',
-    metricName: 'InvocationErrors',
-    period: Duration.minutes(5),
-    statistic: 'Sum',
-  }),
-  threshold: 5,
-  evaluationPeriods: 1,
-  comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-  treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING,
-});
-
 // Alarm: InvocationLatency p99 > 30000 ms in 5 minutes (AWS/Bedrock namespace)
 const invocationLatencyAlarm = new aws_cloudwatch.Alarm(stack, 'BedrockInvocationLatencyAlarm', {
   alarmName: `BrainInCup-${stack.stackName}-InvocationLatency-p99`,
@@ -576,13 +448,12 @@ if (obsConfig.alarmSnsArn) {
   const snsAction = new aws_cloudwatch_actions.SnsAction(
     aws_sns.Topic.fromTopicArn(stack, 'ObservabilityAlarmTopic', obsConfig.alarmSnsArn)
   );
-  invocationErrorsAlarm.addAlarmAction(snsAction);
   invocationLatencyAlarm.addAlarmAction(snsAction);
 } else {
   // Emit alarm ARNs as output when no SNS topic is configured
   new CfnOutput(stack, 'ObservabilityAlarmArns', {
-    value: [invocationErrorsAlarm.alarmArn, invocationLatencyAlarm.alarmArn].join(','),
-    description: 'CloudWatch alarm ARNs for Bedrock observability (configure OBSERVABILITY_ALARM_SNS_ARN to add SNS notifications)',
+    value: invocationLatencyAlarm.alarmArn,
+    description: 'CloudWatch alarm ARN for Bedrock latency (configure OBSERVABILITY_ALARM_SNS_ARN to add SNS notifications)',
   });
 }
 
@@ -661,10 +532,6 @@ dashboard.addWidgets(
   new aws_cloudwatch.GraphWidget({
     title: 'Bedrock Invocation Latency',
     left: [new aws_cloudwatch.Metric({ namespace: 'AWS/Bedrock', metricName: 'InvocationLatency', statistic: 'p99', period: Duration.minutes(5) })],
-  }),
-  new aws_cloudwatch.GraphWidget({
-    title: 'AgentCore Invocation Errors',
-    left: [new aws_cloudwatch.Metric({ namespace: 'bedrock-agentcore', metricName: 'InvocationErrors', statistic: 'Sum', period: Duration.minutes(5) })],
   }),
 );
 

--- a/amplify/functions/brain/app/main.py
+++ b/amplify/functions/brain/app/main.py
@@ -2,7 +2,10 @@
 Brain Lambda — DynamoDB stream handler for the brain function.
 
 Handles Message table stream events, runs the ContextEnrichmentPipeline,
-invokes AgentCore, and writes the BrainResponse back via AppSync.
+invokes Bedrock directly, and writes the BrainResponse back via AppSync.
+
+Previously this routed through a separate AgentCore container runtime.
+The agent-runtime/ directory and Dockerfile are kept for fallback.
 """
 
 from __future__ import annotations
@@ -44,44 +47,61 @@ game event fields in your JSON response: xp_award, hp_change, quest_step_advance
 quest_fail, world_flags_set, dice_roll_request, tension_level, area_transition, current_location, item_grant."""
 
 # ---------------------------------------------------------------------------
-# AgentCore invocation
+# Direct Bedrock invocation (replaces AgentCore container hop)
 # ---------------------------------------------------------------------------
 
-def _get_agentcore_endpoint() -> str:
-    return os.environ.get("AGENTCORE_ENDPOINT", "http://localhost:8080")
+BEDROCK_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
 
 
-def invoke_agentcore(prompt: str, conversation_id: str) -> dict:
+def _get_bedrock_client():
+    return boto3.client("bedrock-runtime", region_name=os.environ.get("AWS_REGION", "us-east-1"))
+
+
+def invoke_bedrock(prompt: str, conversation_id: str) -> dict:
     """
-    Invoke the AgentCore runtime with the enriched prompt.
+    Invoke Bedrock directly with the enriched prompt.
+    Previously this was an HTTP call to the AgentCore container runtime.
     Returns the parsed JSON response dict.
     """
-    import urllib.request
+    bedrock_request = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 2048,
+        "system": GAME_MASTER_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 1.0,
+        "top_p": 1.0,
+    }
 
-    endpoint = _get_agentcore_endpoint()
-    payload = json.dumps({
-        "prompt": prompt,
-        "persona": {
-            "name": "The Game Master",
-            "mode": "game_master",
-            "temperature": 1.0,
-            "top_p": 1.0,
-        },
-        "context": conversation_id,
-        "message": {"id": conversation_id, "owner": ""},
-    }).encode("utf-8")
-
-    req = urllib.request.Request(
-        f"{endpoint}/invocations",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+        client = _get_bedrock_client()
+        response = client.invoke_model(
+            modelId=BEDROCK_MODEL_ID,
+            body=json.dumps(bedrock_request)
+        )
+        model_response = json.loads(response['body'].read())
+        content = model_response.get("content", [])
+        if content and isinstance(content, list) and len(content) > 0:
+            raw_text = content[0].get("text", "")
+        else:
+            raw_text = ""
+
+        try:
+            response_payload = json.loads(raw_text)
+            required_fields = ["sensations", "thoughts", "memories", "self_reflection", "response"]
+            if all(field in response_payload for field in required_fields):
+                return response_payload
+        except json.JSONDecodeError:
+            pass
+
+        return {
+            "sensations": ["Neural pathways activating"],
+            "thoughts": ["Analyzing the question"],
+            "memories": f"Context: {conversation_id}",
+            "self_reflection": "Working to understand and respond meaningfully",
+            "response": raw_text if raw_text else "I processed your message but encountered difficulty generating a structured response.",
+        }
     except Exception as exc:
-        logger.error("AgentCore invocation failed: %s", exc)
+        logger.error("Bedrock invocation failed: %s", exc)
         return {
             "response": "The Game Master is momentarily unavailable.",
             "sensations": [],
@@ -328,8 +348,8 @@ def handle_message_stream_event(record: dict) -> None:
     )
     prompt = (message_content or "") + game_context_block
 
-    # 7. Invoke AgentCore
-    agent_response = invoke_agentcore(prompt, conversation_id)
+    # 7. Invoke Bedrock directly (was AgentCore container runtime)
+    agent_response = invoke_bedrock(prompt, conversation_id)
 
     # 8. Write BrainResponse
     write_brain_response(conversation_id, message_id, agent_response)

--- a/amplify/functions/brain/src/agents/language_agent.py
+++ b/amplify/functions/brain/src/agents/language_agent.py
@@ -1,13 +1,12 @@
 import logging
 from typing import Any, Dict, Optional
 
-from core.agentcore_client import AgentCoreClient
-
 logger = logging.getLogger(__name__)
 
 
 class LanguageAgent:
-    def __init__(self, agent_client: AgentCoreClient, persona_config: Dict[str, Any]):
+    def __init__(self, agent_client, persona_config: Dict[str, Any]):
+        """agent_client: AgentCoreClient or BedrockDirectClient (duck-typed, both implement .invoke())"""
         self.agent_client = agent_client
         self.persona_config = persona_config
         self.memory = []

--- a/amplify/functions/brain/src/core/bedrock_direct_client.py
+++ b/amplify/functions/brain/src/core/bedrock_direct_client.py
@@ -1,0 +1,124 @@
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+
+class BedrockDirectClient:
+    """Direct Bedrock model invocation, replaces AgentCore container round-trip.
+
+    This client calls Bedrock's invoke_model directly instead of routing
+    through the AgentCore managed runtime. The agent-runtime/ directory and
+    Dockerfile are preserved for easy fallback.
+
+    Implements the same interface as AgentCoreClient for duck-typed compatibility.
+    AgentCore-specific memory methods are no-ops in direct mode.
+    """
+
+    def __init__(
+        self,
+        model_id: str = DEFAULT_MODEL_ID,
+        region_name: str = "us-east-1",
+    ) -> None:
+        self.model_id = model_id
+        self.client = boto3.client("bedrock-runtime", region_name=region_name)
+
+    def invoke(
+        self,
+        *,
+        session_id: str,
+        payload: Dict[str, Any],
+        trace_metadata: Optional[str] = None,
+        runtime_user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        prompt = payload.get("prompt", "")
+        persona = payload.get("persona", {})
+        temperature = float(persona.get("temperature", 1.0))
+        top_p = float(persona.get("top_p", 1.0))
+
+        system_prompt = persona.get("name", "You are a helpful AI assistant.")
+
+        bedrock_request = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 2048,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+            "top_p": top_p,
+        }
+
+        try:
+            response = self.client.invoke_model(
+                modelId=self.model_id,
+                body=json.dumps(bedrock_request),
+            )
+            model_response = json.loads(response["body"].read())
+            content = model_response.get("content", [])
+            if content and isinstance(content, list) and len(content) > 0:
+                raw_text = content[0].get("text", "")
+            else:
+                raw_text = ""
+
+            try:
+                return json.loads(raw_text)
+            except json.JSONDecodeError:
+                return {"response": raw_text}
+
+        except Exception as error:
+            logger.error("Bedrock direct invocation failed", exc_info=error)
+            return {
+                "sensations": ["Error processing input"],
+                "thoughts": ["System malfunction"],
+                "memories": "Unable to access memory banks",
+                "self_reflection": "Experiencing technical difficulties",
+                "response": "I'm experiencing technical difficulties and cannot process your request at the moment.",
+            }
+
+    # ------------------------------------------------------------------ #
+    # AgentCore-compatible stubs (memory methods are no-ops in direct mode)
+    # ------------------------------------------------------------------ #
+
+    def retrieve_memory_records(
+        self,
+        *,
+        namespace: str,
+        search_query: str,
+        top_k: int = 5,
+        memory_strategy_id: Optional[str] = None,
+    ) -> List[str]:
+        logger.debug("Memory retrieval is not available in direct Bedrock mode (namespace=%s)", namespace)
+        return []
+
+    def create_short_term_event(
+        self,
+        *,
+        actor_id: str,
+        session_id: str,
+        role: str,
+        text: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> None:
+        pass
+
+    def save_memory_record(
+        self,
+        *,
+        request_identifier: str,
+        namespaces: List[str],
+        content_text: str,
+        memory_strategy_id: Optional[str] = None,
+    ) -> None:
+        pass
+
+    @staticmethod
+    def sanitize_namespace(value: str) -> str:
+        cleaned = re.sub(r"[^a-zA-Z0-9_-]", "-", value or "").strip("-")
+        if not cleaned:
+            return "default"
+        return cleaned[:128]

--- a/amplify/functions/brain/src/core/config.py
+++ b/amplify/functions/brain/src/core/config.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from core.agentcore_client import AgentCoreClient
+from core.bedrock_direct_client import BedrockDirectClient
 
 DEFAULT_BRAIN_PROMPT = """
 You are {name}, a disembodied brain floating in a nutrient-rich liquid, connected to wires and sensors.
@@ -74,27 +75,35 @@ Assistant:
     return prompt_template, persona
 
 
-def setup_agentcore_client():
-    runtime_arn = os.getenv("AGENTCORE_RUNTIME_ARN", "").strip()
-    if not runtime_arn:
-        raise ValueError("AGENTCORE_RUNTIME_ARN environment variable must be set")
+def setup_client():
+    """Create either a direct Bedrock client or an AgentCore client.
 
+    If AGENTCORE_RUNTIME_ARN is set, uses the AgentCore managed runtime (container mode).
+    Otherwise, calls Bedrock directly (direct code mode, default).
+    """
     region_name = os.getenv("AWS_REGION_NAME") or os.getenv("AWS_REGION") or "us-east-1"
-    trace_enabled = os.getenv("AGENTCORE_TRACE_ENABLED", "false").lower() == "true"
-    try:
-        trace_sample_rate = float(os.getenv("AGENTCORE_TRACE_SAMPLE_RATE", "0"))
-    except ValueError:
-        trace_sample_rate = 0.0
-    memory_id = os.getenv("AGENTCORE_MEMORY_ID", "").strip() or None
 
-    logging.info(f"Initializing AgentCore client with runtime: {runtime_arn[:50]}...")
-    return AgentCoreClient(
-        runtime_arn=runtime_arn,
-        region_name=region_name,
-        trace_enabled=trace_enabled,
-        trace_sample_rate=trace_sample_rate,
-        memory_id=memory_id,
-    )
+    runtime_arn = os.getenv("AGENTCORE_RUNTIME_ARN", "").strip()
+    if runtime_arn:
+        logging.info(f"Using AgentCore runtime: {runtime_arn[:50]}...")
+        trace_enabled = os.getenv("AGENTCORE_TRACE_ENABLED", "false").lower() == "true"
+        try:
+            trace_sample_rate = float(os.getenv("AGENTCORE_TRACE_SAMPLE_RATE", "0"))
+        except ValueError:
+            trace_sample_rate = 0.0
+        memory_id = os.getenv("AGENTCORE_MEMORY_ID", "").strip() or None
+
+        return AgentCoreClient(
+            runtime_arn=runtime_arn,
+            region_name=region_name,
+            trace_enabled=trace_enabled,
+            trace_sample_rate=trace_sample_rate,
+            memory_id=memory_id,
+        )
+
+    logging.info("Using direct Bedrock invocation (no AgentCore runtime)")
+    model_id = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
+    return BedrockDirectClient(model_id=model_id, region_name=region_name)
 
 
 class SimpleJSONParser:

--- a/amplify/functions/brain/src/core/controller.py
+++ b/amplify/functions/brain/src/core/controller.py
@@ -14,7 +14,7 @@ from agents import (
     SelfAgent,
     DepthAgent,
 )
-from core.config import setup_agentcore_client, setup_prompt_template, setup_parser
+from core.config import setup_client, setup_prompt_template, setup_parser
 from core.mode_handlers import create_mode_handler
 
 # Set up logging
@@ -33,7 +33,7 @@ class Controller:
         self.personality_mode = personality_mode or "default"
         prompt_template, persona_config = setup_prompt_template(self.personality_mode)
         parser = setup_parser()
-        agentcore_client = setup_agentcore_client()
+        agentcore_client = setup_client()
 
         # Initialize agents
         self.perception_agent = PerceptionAgent(

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,68 +5,97 @@
 Deploy everything with a single command:
 
 ```bash
-npm run deploy
+npm run deploy:all
 ```
 
-That's it! The script will automatically:
+That's it! The script will:
 1. ✅ Detect your AWS account ID
 2. ✅ Build the Lambda layer
-3. ✅ Check if AgentCore container exists
-4. ✅ Build and push container if needed
-5. ✅ Deploy the Amplify sandbox with AgentCore runtime
+3. ✅ Deploy the Amplify sandbox
+4. ✅ Sync images to CDN
+
+No Docker required.
 
 ## Prerequisites
 
-- **Docker** running locally
 - **AWS CLI** configured with credentials
 - **AWS Profile** named `brain` (or set `AWS_PROFILE` env var)
 - Node.js 18+ and npm
 
-## Environment Configuration
+## Deployment Mode: Direct Code (Default)
 
-All configuration is auto-detected! No hardcoded values needed.
+The Lambda function calls Bedrock directly. There is no separate AgentCore container
+runtime — the model invocation code is bundled with the Lambda. This eliminates the
+Docker build step from the dev loop.
 
-Optional settings in `.env.agentcore`:
-- `AGENTCORE_NETWORK_MODE`: `PUBLIC` or `VPC` (default: `PUBLIC`)
-- `AGENTCORE_TRACE_ENABLED`: Enable tracing (default: `false`)
-- `AGENTCORE_TRACE_SAMPLE_RATE`: Trace sample rate 0.0-1.0 (default: `0.0`)
+### Deploy
 
-## Individual Commands
-
-If you need more control:
-
-### Build and Push AgentCore Container Only
 ```bash
-./scripts/update-agent-image.sh
-```
-
-### Deploy Without Rebuilding Container
-```bash
-npm run sandbox
+npm run deploy:sandbox    # Build layer + deploy Amplify sandbox
+npm run deploy:images     # Sync game images to CDN
+npm run deploy:all        # Both of the above
 ```
 
 ### View Live Logs
+
 ```bash
 npm run logs
 ```
 
 ### Delete Sandbox
+
 ```bash
-npm run sandbox:delete
+npm run delete:sandbox
 ```
+
+## Switching to Container Mode
+
+The original AgentCore container setup is preserved and ready to use. To switch back:
+
+1. **Build and push the container:**
+   ```bash
+   npm run deploy:container  # Builds Docker image, pushes to ECR, then deploys
+   ```
+
+2. **Or step by step:**
+   ```bash
+   # Build and push the AgentCore container
+   ./scripts/update-agent-image.sh
+
+   # Deploy Amplify sandbox (detects AGENTCORE_CONTAINER_URI)
+   npm run deploy:sandbox
+   ```
+
+3. **To restore the full container deployment pipeline:**
+   - Uncomment the AgentCore runtime block in `amplify/backend.ts` (search for "AgentCore")
+   - Revert `amplify/functions/brain/app/main.py` to use `invoke_agentcore()` instead of `invoke_bedrock()`
+   - See `agent-runtime/README.md` for the container runtime details
+
+## Environment Configuration
+
+Optional settings in `.env.agentcore`:
+
+- `BEDROCK_MODEL_ID`: Bedrock model to use (default: `anthropic.claude-3-sonnet-20240229-v1:0`)
+- `AGENTCORE_TRACE_ENABLED`: Enable tracing (default: `true`)
+- `AGENTCORE_TRACE_SAMPLE_RATE`: Trace sample rate 0.0-1.0 (default: `1.0`)
 
 ## How It Works
 
-### First Deployment
-1. Builds AgentCore Docker container from `agent-runtime/`
-2. Pushes to ECR (auto-detected: `{account}.dkr.ecr.us-east-1.amazonaws.com/brain-agent`)
-3. Creates `AWS::BedrockAgentCore::Runtime` with the container
-4. Deploys Lambda, DynamoDB, AppSync, Cognito, etc.
+### Direct Code Mode (Current)
 
-### Subsequent Deployments
-- Reuses existing container if found
-- Updates AgentCore runtime if container changed
-- Hotswaps Lambda code for faster deploys
+1. Lambda layer builds Python dependencies for the runtime
+2. Amplify sandbox deploys Lambda, DynamoDB, AppSync, Cognito, S3, CloudFront
+3. Lambda receives DynamoDB stream events from the Message table
+4. Lambda runs the ContextEnrichmentPipeline to build a game context
+5. Lambda calls Bedrock directly with the enriched prompt
+6. Lambda writes the BrainResponse back via AppSync
+
+### Container Mode (Fallback)
+
+1. Builds AgentCore Docker container from `agent-runtime/`
+2. Pushes to ECR
+3. Creates `AWS::BedrockAgentCore::Runtime` with the container
+4. Lambda routes prompts to AgentCore via HTTP instead of calling Bedrock directly
 
 ## Authentication Setup (Optional)
 
@@ -74,34 +103,32 @@ npm run sandbox:delete
 
 To enable Google and Facebook login:
 
-1. **Configure secrets in AWS Parameter Store**:
+1. **Configure secrets in AWS Parameter Store:**
    ```bash
    # Google OAuth
    aws ssm put-parameter --name /amplify/brain-in-cup/GOOGLE_CLIENT_ID \
      --value "your-google-client-id" --type SecureString
-   
+
    aws ssm put-parameter --name /amplify/brain-in-cup/GOOGLE_CLIENT_SECRET \
      --value "your-google-client-secret" --type SecureString
-   
+
    # Facebook OAuth
    aws ssm put-parameter --name /amplify/brain-in-cup/FACEBOOK_CLIENT_ID \
      --value "your-facebook-client-id" --type SecureString
-   
+
    aws ssm put-parameter --name /amplify/brain-in-cup/FACEBOOK_CLIENT_SECRET \
      --value "your-facebook-client-secret" --type SecureString
    ```
 
-2. **Deploy normally**:
+2. **Deploy normally:**
    ```bash
-   npm run deploy
+   npm run deploy:all
    ```
 
 ### Development Without External Providers
 
-Set `AMPLIFY_EXTERNAL_PROVIDERS=false` to use default values:
-
 ```bash
-AMPLIFY_EXTERNAL_PROVIDERS=false npm run deploy
+AMPLIFY_EXTERNAL_PROVIDERS=false npm run deploy:sandbox
 ```
 
 ## Troubleshooting
@@ -110,25 +137,6 @@ AMPLIFY_EXTERNAL_PROVIDERS=false npm run deploy
 Make sure AWS credentials are configured:
 ```bash
 aws sts get-caller-identity --profile brain
-```
-
-### "Docker is not running"
-Start Docker Desktop and try again.
-
-### "ECR repository does not exist"
-The script will create it automatically on first run.
-
-### AgentCore Runtime Errors
-Check logs:
-```bash
-npm run logs
-```
-
-Look for errors in CloudFormation:
-```bash
-aws cloudformation describe-stack-events \
-  --stack-name amplify-brainincup-{user}-sandbox-{id} \
-  --region us-east-1
 ```
 
 ### Lambda Layer Build Issues
@@ -141,146 +149,43 @@ If you see import errors like "No module named 'pydantic_core._pydantic_core'":
 
 This rebuilds Python dependencies compatible with AWS Lambda.
 
+### Bedrock Invocation Errors
+Check logs:
+```bash
+npm run logs
+```
+
+Look for errors in CloudFormation:
+```bash
+aws cloudformation describe-stack-events \
+  --stack-name amplify-brainincup-{user}-sandbox-{id} \
+  --region us-east-1
+```
+
+## Architecture
+
+### Direct Code Runtime
+Brain calls Bedrock directly from the Lambda function:
+- Lambda: Python runtime with Bedrock SDK
+- Model invocations happen inline, no HTTP hop
+
+### Backend Stack
+- **Lambda**: Main Brain function with game logic and Bedrock invocation
+- **DynamoDB**: Game state, conversations, quest logs
+- **AppSync**: GraphQL API with real-time subscriptions
+- **Cognito**: User authentication and authorization
+- **S3 + CloudFront**: Image CDN
+- **CloudWatch**: Logging and monitoring
+
 ## CI/CD
 
-For automated deployments, set these environment variables:
-- `AWS_REGION` (default: `us-east-1`)
-- `AWS_PROFILE` (default: `brain`)
-- `REPO` (default: `brain-agent`)
-- `IMAGE_TAG` (default: `latest`)
+For automated deployments:
 
-Example GitHub Actions:
 ```yaml
 - name: Deploy
   env:
     AWS_REGION: us-east-1
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  run: npm run deploy
+  run: npm run deploy:all
 ```
-
-## Architecture
-
-### AgentCore Runtime
-Brain uses AWS Bedrock AgentCore for managed AI agent execution:
-- Container: Custom Python runtime with LangChain
-- Memory: Persistent conversation context and world state
-- Tools: Function calling for game mechanics
-
-### Backend Stack
-- **Lambda**: Main Brain function with AgentCore client
-- **DynamoDB**: Game state, conversations, quest logs
-- **AppSync**: GraphQL API with real-time subscriptions
-- **Cognito**: User authentication and authorization
-- **CloudWatch**: Logging and monitoring
-
-**Troubleshooting:**
-- See `scripts/README.md` for detailed documentation
-- See `amplify/functions/brain/README.md` for function-specific details
-- If you see import errors for aws_lambda_powertools or pydantic, rebuild the layer
-- Make sure Docker is running before executing the script
-
-## Deployment Options
-
-### Option 1: Local Development Deployment (Recommended)
-
-Deploy with default values for external authentication providers:
-
-```bash
-npm run sandbox:local
-```
-
-This sets `AMPLIFY_EXTERNAL_PROVIDERS=false` and uses default values for Google/Facebook secrets, allowing deployment to succeed without configuring real secrets.
-
-### Option 2: Production Deployment
-
-Deploy with all external providers (requires secrets to be configured):
-
-```bash
-npm run sandbox
-```
-
-### Option 3: Using the Deployment Script
-
-```bash
-# For development
-./scripts/sandbox-deploy.sh --no-external-providers
-
-# For production
-./scripts/sandbox-deploy.sh
-```
-
-### Option 4: Manual Environment Variable Control
-
-```bash
-# Disable external providers
-AMPLIFY_EXTERNAL_PROVIDERS=false npx ampx sandbox
-
-# Enable external providers (default)
-AMPLIFY_EXTERNAL_PROVIDERS=true npx ampx sandbox
-```
-
-## Setting Up External Provider Secrets
-
-When you're ready to enable external providers, configure the required secrets:
-
-```bash
-# Set Google secrets
-npx ampx sandbox secret set GOOGLE_CLIENT_ID
-npx ampx sandbox secret set GOOGLE_CLIENT_SECRET
-
-# Set Facebook secrets
-npx ampx sandbox secret set FACEBOOK_CLIENT_ID
-npx ampx sandbox secret set FACEBOOK_CLIENT_SECRET
-```
-
-Then deploy with external providers enabled:
-
-```bash
-npm run sandbox
-```
-
-## CI/CD Integration
-
-For CI/CD pipelines where external provider secrets might not be available:
-
-```yaml
-# GitHub Actions example
-- name: Deploy Amplify Sandbox
-  run: AMPLIFY_EXTERNAL_PROVIDERS=false npx ampx sandbox --once
-  env:
-    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-```
-
-## Configuration Details
-
-The authentication configuration in `amplify/auth/resource.ts` uses conditional logic:
-
-```typescript
-const shouldIncludeExternalProviders = process.env.AMPLIFY_EXTERNAL_PROVIDERS !== 'false';
-
-export const auth = defineAuth({
-  loginWith: {
-    email: true,
-    externalProviders: shouldIncludeExternalProviders 
-      ? externalProvidersWithSecrets 
-      : baseExternalProviders
-  },
-  // ... rest of configuration
-});
-```
-
-## Troubleshooting
-
-**Q: I'm getting "Failed to retrieve backend secret" errors**
-A: Use `npm run sandbox:no-external` to deploy without external providers
-
-**Q: External providers aren't working after deployment**
-A: Make sure you've configured the required secrets and deployed with `npm run sandbox`
-
-**Q: How do I know if external providers are enabled?**
-A: Check the console output during deployment for the warning message
-
-**Q: Can I switch between modes after deployment?**
-A: Yes, just redeploy with the desired configuration using the appropriate script

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "vitest --run",
     "delete:sandbox": "bash ./scripts/delete-sandbox.sh",
     "deploy:sandbox": "bash ./scripts/deploy-sandbox.sh",
-    "deploy:runtime": "bash ./scripts/update-agent-image.sh",
     "deploy:images": "bash ./scripts/sync-images-to-cdn.sh",
     "optimize:images": "bash ./scripts/optimize-images.sh",
-    "deploy:all": "bash ./scripts/update-agent-image.sh && bash ./scripts/deploy-sandbox.sh && bash ./scripts/sync-images-to-cdn.sh",
+    "deploy:all": "bash ./scripts/deploy-sandbox.sh && bash ./scripts/sync-images-to-cdn.sh",
+    "deploy:container": "bash ./scripts/update-agent-image.sh && bash ./scripts/deploy-sandbox.sh && bash ./scripts/sync-images-to-cdn.sh",
     "logs": "bash ./scripts/fetch-logs.sh"
   },
   "dependencies": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,10 +15,6 @@ Builds the Lambda layer with Python dependencies for the Brain function.
 ./scripts/build-lambda-layer.sh
 ```
 
-**Requirements**:
-- Docker (recommended) OR Python 3.12 with pip
-- Internet connection to download dependencies
-
 **What it does**:
 1. Cleans existing layer directory
 2. Installs Python packages for Linux x86_64 / Python 3.12
@@ -31,19 +27,17 @@ Builds the Lambda layer with Python dependencies for the Brain function.
 - When Lambda import errors occur
 - When switching between development machines
 
-**Troubleshooting**:
-- If Docker not available, script automatically falls back to pip with platform flags
-- Start Docker Desktop if you see "Docker daemon not running"
-- See `amplify/functions/brain/README.md` for detailed troubleshooting
-
 ## Quick Reference
 
 ```bash
 # Build Lambda layer
 ./scripts/build-lambda-layer.sh
 
-# Deploy to sandbox
-npx ampx sandbox --profile brain
+# Deploy to sandbox (direct Bedrock mode, no Docker)
+./scripts/deploy-sandbox.sh
+
+# Deploy with container (requires Docker)
+./scripts/update-agent-image.sh && ./scripts/deploy-sandbox.sh
 
 # Local development
 npm run dev

--- a/scripts/delete-sandbox.sh
+++ b/scripts/delete-sandbox.sh
@@ -9,31 +9,5 @@ cd "${PROJECT_ROOT}"
 export AWS_PROFILE="${AWS_PROFILE:-brain}"
 export AWS_PAGER="${AWS_PAGER:-}"
 
-# Prefer explicit local config first.
-if [ -f "${PROJECT_ROOT}/.env.agentcore" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  source "${PROJECT_ROOT}/.env.agentcore"
-  set +a
-fi
-
-# Fallback to discovery script when required vars are missing.
-if [ -z "${AGENTCORE_RUNTIME_ARN:-}" ] && [ -z "${AGENTCORE_CONTAINER_URI:-}" ]; then
-  # shellcheck source=/dev/null
-  source "${SCRIPT_DIR}/setup-agentcore-env.sh" <<< "y"
-fi
-
-if [ -z "${AGENTCORE_RUNTIME_ARN:-}" ] && [ -z "${AGENTCORE_CONTAINER_URI:-}" ]; then
-  echo "❌ Error: AgentCore runtime configuration is missing."
-  echo "Set AGENTCORE_RUNTIME_ARN or AGENTCORE_CONTAINER_URI, then rerun."
-  exit 1
-fi
-
-export AGENTCORE_RUNTIME_ARN="${AGENTCORE_RUNTIME_ARN:-}"
-export AGENTCORE_CONTAINER_URI="${AGENTCORE_CONTAINER_URI:-}"
-export AGENTCORE_RUNTIME_NAME="${AGENTCORE_RUNTIME_NAME:-}"
-export AGENTCORE_NETWORK_MODE="${AGENTCORE_NETWORK_MODE:-}"
-export AGENTCORE_TRACE_ENABLED="${AGENTCORE_TRACE_ENABLED:-}"
-export AGENTCORE_TRACE_SAMPLE_RATE="${AGENTCORE_TRACE_SAMPLE_RATE:-}"
-
+echo "🗑️  Deleting Amplify sandbox..."
 NODE_OPTIONS=--no-experimental-webstorage npx ampx sandbox delete --yes "$@"

--- a/scripts/deploy-sandbox.sh
+++ b/scripts/deploy-sandbox.sh
@@ -34,31 +34,6 @@ echo "🔨 Building Lambda layer..."
 "${SCRIPT_DIR}/build-lambda-layer.sh"
 echo ""
 
-# Setup AgentCore environment automatically
-REPO="${REPO:-brain-agent}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
-
-# Check if ECR image exists — use `npm run deploy:all` to also rebuild the runtime image
-echo "🔍 Checking for AgentCore container image..."
-CONTAINER_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:$IMAGE_TAG"
-
-if ! aws ecr describe-images --region "$AWS_REGION" --repository-name "$REPO" --image-ids imageTag="$IMAGE_TAG" >/dev/null 2>&1; then
-  echo "📦 Container image not found, building and pushing..."
-  "${SCRIPT_DIR}/update-agent-image.sh"
-else
-  echo "✅ Container image found: $CONTAINER_URI"
-fi
-echo ""
-
-# Set AgentCore environment variables
-export AGENTCORE_CONTAINER_URI="$CONTAINER_URI"
-export AGENTCORE_NETWORK_MODE="PUBLIC"
-
-echo "🌐 AgentCore Configuration:"
-echo "   Container: $AGENTCORE_CONTAINER_URI"
-echo "   Network: $AGENTCORE_NETWORK_MODE"
-echo ""
-
 # Deploy
 echo "🚢 Deploying Amplify sandbox..."
 AMPLIFY_EXTERNAL_PROVIDERS=false NODE_OPTIONS=--no-experimental-webstorage npx ampx sandbox --once

--- a/scripts/run-sandbox.sh
+++ b/scripts/run-sandbox.sh
@@ -17,15 +17,5 @@ if [ -n "${EXISTING_SANDBOX_PIDS// }" ]; then
   exit 1
 fi
 
-echo "== Setup AgentCore env =="
-# shellcheck source=/dev/null
-source "${SCRIPT_DIR}/setup-agentcore-env.sh" <<< "y"
-
-if [ -z "${AGENTCORE_RUNTIME_ARN:-}" ] && [ -z "${AGENTCORE_CONTAINER_URI:-}" ]; then
-  echo "❌ Error: AgentCore runtime configuration is missing."
-  echo "Set AGENTCORE_RUNTIME_ARN or AGENTCORE_CONTAINER_URI, then rerun."
-  exit 1
-fi
-
-echo "== Run Amplify sandbox =="
+echo "🚀 Running Amplify sandbox (direct Bedrock mode)..."
 NODE_OPTIONS=--no-experimental-webstorage npx ampx sandbox --once

--- a/scripts/setup-agentcore-env.sh
+++ b/scripts/setup-agentcore-env.sh
@@ -2,108 +2,30 @@
 set -e
 
 # AgentCore Environment Setup Script
-# Automatically retrieves and sets required environment variables for deployment
+# Automatically retrieves and sets required environment variables.
+# In direct code mode, the Lambda calls Bedrock directly and does not
+# require any AgentCore runtime ARN or container URI.
+# These variables configure observability and tracing only.
 
-# Configuration
 AWS_REGION="${AWS_REGION:-us-east-1}"
 AWS_PROFILE="${AWS_PROFILE:-brain}"
 
-# Auto-detect AWS account ID
-ACCOUNT_ID="${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")}"
-if [ -z "$ACCOUNT_ID" ]; then
-  echo "❌ Error: Could not determine AWS account ID"
-  echo "   Make sure AWS credentials are configured"
-  exit 1
-fi
-
-REPO="${REPO:-brain-agent}"
-STACK_NAME_PATTERN="amplify-brainincup-*-sandbox-*"
-TRACE_ENABLED_VALUE="${AGENTCORE_TRACE_ENABLED:-false}"
-TRACE_SAMPLE_RATE_VALUE="${AGENTCORE_TRACE_SAMPLE_RATE:-0.0}"
-
-echo "🔧 AgentCore Environment Setup"
-echo "=============================="
+echo "🔧 Environment Setup (Direct Bedrock Mode)"
+echo "=========================================="
 echo ""
 echo "📍 Region: $AWS_REGION"
-echo "🔢 Account: $ACCOUNT_ID"
+echo ""
+echo "ℹ️  This project is configured for direct Bedrock invocation."
+echo "   No AgentCore runtime ARN or container URI is needed."
+echo "   See agent-runtime/README.md to switch back to container mode."
 echo ""
 
-# Check AWS CLI
-if ! command -v aws &> /dev/null; then
-  echo "❌ Error: AWS CLI is not installed"
-  exit 1
-fi
+export AGENTCORE_TRACE_ENABLED="${AGENTCORE_TRACE_ENABLED:-true}"
+export AGENTCORE_TRACE_SAMPLE_RATE="${AGENTCORE_TRACE_SAMPLE_RATE:-1.0}"
 
-# Get the latest deployed root stack name
-echo "🔍 Finding Amplify stack..."
-STACK_NAME=$(aws cloudformation list-stacks \
-  --region "$AWS_REGION" \
-  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
-  --query "StackSummaries[?starts_with(StackName, 'amplify-brainincup-')].StackName" \
-  --output text | tr '\t' '\n' | grep -E '^amplify-brainincup-.*-sandbox-[A-Za-z0-9]+$' | head -n 1 || true)
-
-if [ -z "$STACK_NAME" ]; then
-  echo "⚠️  No deployed Amplify stack found"
-  echo "   Using container URI method instead..."
-  AGENTCORE_RUNTIME_ARN=""
-else
-  echo "✅ Found stack: $STACK_NAME"
-  echo ""
-  
-  # Try to get AgentCore runtime ARN from stack outputs
-  echo "🔍 Looking for AgentCore runtime ARN..."
-  AGENTCORE_RUNTIME_ARN=$(aws cloudformation describe-stacks \
-    --region "$AWS_REGION" \
-    --stack-name "$STACK_NAME" \
-    --query "Stacks[0].Outputs[?OutputKey=='AgentCoreRuntimeArn'].OutputValue" \
-    --output text 2>/dev/null || echo "")
-fi
-
-# Get container URI
-echo "🔍 Getting container URI from ECR..."
-CONTAINER_URI=$(aws ecr describe-images \
-  --region "$AWS_REGION" \
-  --repository-name "$REPO" \
-  --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]" \
-  --output text 2>/dev/null || echo "")
-
-if [ -n "$CONTAINER_URI" ] && [ "$CONTAINER_URI" != "None" ]; then
-  AGENTCORE_CONTAINER_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:$CONTAINER_URI"
-else
-  AGENTCORE_CONTAINER_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:latest"
-fi
-
-# Display configuration
+echo "export AGENTCORE_TRACE_ENABLED='${AGENTCORE_TRACE_ENABLED}'"
+echo "export AGENTCORE_TRACE_SAMPLE_RATE='${AGENTCORE_TRACE_SAMPLE_RATE}'"
 echo ""
-echo "📋 Environment Variables"
-echo "========================"
-echo ""
-
-if [ -n "$AGENTCORE_RUNTIME_ARN" ]; then
-  echo "export AGENTCORE_RUNTIME_ARN='$AGENTCORE_RUNTIME_ARN'"
-  echo ""
-  echo "✅ Using existing runtime ARN from stack"
-else
-  echo "export AGENTCORE_CONTAINER_URI='$AGENTCORE_CONTAINER_URI'"
-  echo "export AGENTCORE_NETWORK_MODE='PUBLIC'"
-  echo ""
-  echo "✅ Using container URI to provision new runtime"
-fi
-
-echo "export AGENTCORE_TRACE_ENABLED='${TRACE_ENABLED_VALUE}'"
-echo "export AGENTCORE_TRACE_SAMPLE_RATE='${TRACE_SAMPLE_RATE_VALUE}'"
-echo ""
-
-# Auto-export by default (non-interactive mode)
-if [ -n "$AGENTCORE_RUNTIME_ARN" ]; then
-  export AGENTCORE_RUNTIME_ARN="$AGENTCORE_RUNTIME_ARN"
-else
-  export AGENTCORE_CONTAINER_URI="$AGENTCORE_CONTAINER_URI"
-  export AGENTCORE_NETWORK_MODE="PUBLIC"
-fi
-
-export AGENTCORE_TRACE_ENABLED="${TRACE_ENABLED_VALUE}"
-export AGENTCORE_TRACE_SAMPLE_RATE="${TRACE_SAMPLE_RATE_VALUE}"
 
 echo "✅ Variables exported"
 echo ""


### PR DESCRIPTION
## Summary

Removes the AgentCore container infrastructure and replaces it with direct `boto3` Bedrock `invoke_model()` calls. Deploy no longer requires Docker.

### What changed

- **`BedrockDirectClient`** — new client class that talks directly to Bedrock via boto3, duck-typed to match `AgentCoreClient`
- **Config auto-selection** — `setup_client()` picks AgentCore or direct Bedrock based on whether `AGENTCORE_RUNTIME_ARN` is set
- **CDK simplified** — removed IAM role, CloudWatch alarms, dashboard widget for AgentCore; added `bedrock:InvokeModel` IAM statement
- **Deploy scripts** — no more Docker/ECR requirements
- **Docs** — rewritten for direct Bedrock as default, with instructions to switch back to container mode

### Files

| File | Change |
|------|--------|
| `amplify/functions/brain/src/core/bedrock_direct_client.py` | New — direct Bedrock client |
| `amplify/functions/brain/app/main.py` | Core refactor — direct invoke_model() |
| `amplify/functions/brain/src/core/config.py` | Auto-select client type |
| `amplify/functions/brain/src/core/controller.py` | Import rename |
| `amplify/functions/brain/src/agents/language_agent.py` | Duck-typed client |
| `amplify/backend.ts` | Remove AgentCore infra, add Bedrock IAM |
| `package.json` | Updated deploy scripts |
| `scripts/*` | Remove Docker/AgentCore requirements |
| `docs/DEPLOYMENT.md` | Rewritten for direct Bedrock |
| `.gitignore` | Added `.env.agentcore` |