### PR TITLE
fix(backend): update Bedrock model to active inference profile and improve error handling

### DIFF
--- a/agent-runtime/app/main.py
+++ b/agent-runtime/app/main.py
@@ -42,7 +42,7 @@ class BrainAgent:
     """
     
     def __init__(self):
-        self.model_id = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
+        self.model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
         self.bedrock_client = boto3.client('bedrock-runtime', region_name=os.getenv("AWS_REGION", "us-east-1"))
         logger.info(f"BrainAgent initialized with model: {self.model_id}")
     

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -231,7 +231,7 @@ brainLambda.addEnvironment('APPSYNC_API_URL', backend.data.resources.cfnResource
 brainLambda.addEnvironment('AWS_REGION_NAME', stack.region);
 
 // Add Bedrock model ID env var for direct invocation
-brainLambda.addEnvironment('BEDROCK_MODEL_ID', getAgentCoreConfig('BEDROCK_MODEL_ID') ?? 'anthropic.claude-3-sonnet-20240229-v1:0');
+brainLambda.addEnvironment('BEDROCK_MODEL_ID', getAgentCoreConfig('BEDROCK_MODEL_ID') ?? 'us.anthropic.claude-haiku-4-5-20251001-v1:0');
 
 // Note: Previously this code created an AWS::BedrockAgentCore::Runtime with a
 // container image. The Lambda now calls Bedrock directly, eliminating the
@@ -251,7 +251,21 @@ new EventSourceMapping(stack, 'BrainMessageMapping', {
 
 brainLambda.addToRolePolicy(new PolicyStatement({
   actions: ['bedrock:InvokeModel'],
-  resources: [`arn:aws:bedrock:${stack.region}::foundation-model/*`],
+  resources: [
+    `arn:aws:bedrock:${stack.region}::foundation-model/*`,
+    `arn:aws:bedrock:${stack.region}:${stack.account}:inference-profile/*`,
+    'arn:aws:bedrock:*::foundation-model/*',
+    `arn:aws:bedrock:*:${stack.account}:inference-profile/*`,
+  ],
+  effect: Effect.ALLOW,
+}));
+
+brainLambda.addToRolePolicy(new PolicyStatement({
+  actions: [
+    'aws-marketplace:ViewSubscriptions',
+    'aws-marketplace:Subscribe',
+  ],
+  resources: ['*'],
   effect: Effect.ALLOW,
 }));
 

--- a/amplify/functions/brain/app/main.py
+++ b/amplify/functions/brain/app/main.py
@@ -50,7 +50,7 @@ quest_fail, world_flags_set, dice_roll_request, tension_level, area_transition, 
 # Direct Bedrock invocation (replaces AgentCore container hop)
 # ---------------------------------------------------------------------------
 
-BEDROCK_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
+BEDROCK_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 
 
 def _get_bedrock_client():

--- a/amplify/functions/brain/src/agents/language_agent.py
+++ b/amplify/functions/brain/src/agents/language_agent.py
@@ -42,9 +42,15 @@ class LanguageAgent:
                 trace_metadata=metadata.get("trace_id"),
                 runtime_user_id=metadata.get("owner"),
             )
-            return response or self._fallback_response()
+            if not response:
+                logger.error("Agent returned empty response", extra={"session_id": session_id})
+                return self._fallback_response()
+            if isinstance(response, dict) and "sensations" in response and response.get("sensations") == ["Error processing input"]:
+                logger.error("Agent returned error response", extra={"response": response, "session_id": session_id})
+                return self._fallback_response()
+            return response
         except Exception as error:
-            logger.error("AgentCore invocation failed", exc_info=error)
+            logger.error("Agent invocation failed", exc_info=error)
             return self._fallback_response()
 
     @staticmethod

--- a/amplify/functions/brain/src/core/bedrock_direct_client.py
+++ b/amplify/functions/brain/src/core/bedrock_direct_client.py
@@ -7,7 +7,7 @@ import boto3
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+DEFAULT_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 class BedrockDirectClient:
@@ -50,7 +50,6 @@ class BedrockDirectClient:
             "system": system_prompt,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": temperature,
-            "top_p": top_p,
         }
 
         try:
@@ -64,6 +63,7 @@ class BedrockDirectClient:
                 raw_text = content[0].get("text", "")
             else:
                 raw_text = ""
+                logger.error("Bedrock returned empty content", extra={"model_id": self.model_id, "response": model_response})
 
             try:
                 return json.loads(raw_text)
@@ -71,7 +71,7 @@ class BedrockDirectClient:
                 return {"response": raw_text}
 
         except Exception as error:
-            logger.error("Bedrock direct invocation failed", exc_info=error)
+            logger.error("Bedrock direct invocation failed", extra={"model_id": self.model_id, "error_type": type(error).__name__}, exc_info=error)
             return {
                 "sensations": ["Error processing input"],
                 "thoughts": ["System malfunction"],

--- a/amplify/functions/brain/src/core/config.py
+++ b/amplify/functions/brain/src/core/config.py
@@ -102,7 +102,7 @@ def setup_client():
         )
 
     logging.info("Using direct Bedrock invocation (no AgentCore runtime)")
-    model_id = os.getenv("BEDROCK_MODEL_ID", "anthropic.claude-3-sonnet-20240229-v1:0")
+    model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
     return BedrockDirectClient(model_id=model_id, region_name=region_name)
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -75,7 +75,7 @@ The original AgentCore container setup is preserved and ready to use. To switch 
 
 Optional settings in `.env.agentcore`:
 
-- `BEDROCK_MODEL_ID`: Bedrock model to use (default: `anthropic.claude-3-sonnet-20240229-v1:0`)
+- `BEDROCK_MODEL_ID`: Bedrock model to use (default: `us.anthropic.claude-haiku-4-5-20251001-v1:0`)
 - `AGENTCORE_TRACE_ENABLED`: Enable tracing (default: `true`)
 - `AGENTCORE_TRACE_SAMPLE_RATE`: Trace sample rate 0.0-1.0 (default: `1.0`)
 


### PR DESCRIPTION
## Summary

Fixes the Bedrock AI calls failing with 'technical difficulties' error by:
- Switching from legacy model to active inference profile
- Adding IAM permissions for inference profiles and AWS Marketplace access
- Improving error logging

## Changes

- Updated model ID to  (ACTIVE)
- Added IAM permissions for  on inference profiles
- Added  and  permissions
- Improved error handling in  and 
- Updated all model ID references across codebase

## Root Cause

The original model  was marked as Legacy by AWS/Anthropic and hasn't been used in 30 days, causing Bedrock to reject all invocations with .