### PR TITLE
fix(game-master): use correct tools format for Bedrock invoke_model

### DIFF
--- a/amplify/functions/brain/layer/requirements.txt
+++ b/amplify/functions/brain/layer/requirements.txt
@@ -1,3 +1,4 @@
 aws_lambda_powertools==3.20.0
 pydantic>=2.0.0,<3.0.0
 requests>=2.32.3
+langgraph>=1.2.0

--- a/amplify/functions/brain/src/experiences/game_master/experience.py
+++ b/amplify/functions/brain/src/experiences/game_master/experience.py
@@ -1,31 +1,24 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
 
 from experiences.base import BaseExperience, ExperienceContext, ExperienceResponse
-from experiences.game_master.tools import get_tool_policy
+from experiences.game_master.gm_agent import build_gm_agent, GMAgentState
 from experiences.game_master.memory import load_player_state
+from experiences.game_master.tools import get_tool_policy
 
 logger = logging.getLogger(__name__)
 
+_GM_AGENT = None
 
-def _try_parse_json_response(raw_text: str) -> dict | None:
-    text = raw_text.strip()
-    if text.startswith("```"):
-        end = text.find("```", 3)
-        if end != -1:
-            text = text[3:end].strip()
-        else:
-            text = text[3:].strip()
-    if text.startswith("json"):
-        text = text[4:].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return None
+
+def _get_gm_agent():
+    global _GM_AGENT
+    if _GM_AGENT is None:
+        _GM_AGENT = build_gm_agent()
+    return _GM_AGENT
 
 
 class GameMasterExperience(BaseExperience):
@@ -64,12 +57,11 @@ class GameMasterExperience(BaseExperience):
         return self._tool_policy
 
     def process_message(self, ctx: ExperienceContext) -> ExperienceResponse:
-        """Process a message through the Game Master pipeline.
+        """Process a message through the LangGraph Game Master agent.
 
-        Assembles enriched game context (PlayerState, WorldState, pacing,
-        active scenario, eligible surprises), appends a [GAME_CONTEXT] block
-        to the user message, invokes Bedrock directly, parses the structured
-        JSON response, applies game events, and persists the response.
+        Assembles enriched game context, invokes the agent graph (which
+        may call tools like roll_dice, update_quest, etc. in a loop),
+        then returns the final narrative response.
         """
         logger.info(
             "Game Master experience processing message",
@@ -88,39 +80,51 @@ class GameMasterExperience(BaseExperience):
             )
 
     def _run_gm_pipeline(self, ctx: ExperienceContext) -> ExperienceResponse:
-        """Execute the full GM pipeline: context assembly, LLM invoke, event processing."""
+        """Execute the GM agent graph: context assembly → agent loop → response."""
         player_state = load_player_state(self._dynamodb_client, ctx.conversation_id)
-
         game_context = self._assemble_game_context(player_state)
 
-        game_context_block = (
-            "\n\n[GAME_CONTEXT]\n"
-            + json.dumps({"gameContext": game_context}, indent=2)
-            + "\n[/GAME_CONTEXT]"
+        model_id = os.environ.get(
+            "BEDROCK_MODEL_ID",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         )
-        prompt = (ctx.user_input or "") + game_context_block
+        region = os.environ.get("AWS_REGION", "us-east-1")
 
-        agent_response = self._invoke_bedrock(prompt, ctx.conversation_id)
+        agent = _get_gm_agent()
+
+        initial_state: GMAgentState = {
+            "conversation_id": ctx.conversation_id,
+            "user_input": ctx.user_input or "",
+            "player_state": player_state,
+            "game_context": game_context,
+            "system_prompt": self.get_system_prompt(),
+            "messages": [],
+            "final_response": "",
+            "response_metadata": {},
+            "model_id": model_id,
+            "region": region,
+            "tool_call_count": 0,
+        }
+
+        result = agent.invoke(initial_state)
+
+        response_text = result.get("final_response", "")
+        if not response_text:
+            response_text = "The world shifts around you, but the vision fades before it fully forms..."
 
         return ExperienceResponse(
-            response=agent_response.get("response", "The world shifts around you, but the vision fades before it fully forms..."),
-            raw=agent_response,
+            response=response_text,
+            raw=result,
             metadata={
-                "sensations": agent_response.get("sensations", []),
-                "thoughts": agent_response.get("thoughts", []),
-                "memories": agent_response.get("memories", ""),
-                "self_reflection": agent_response.get("self_reflection", ""),
-                "xp_award": agent_response.get("xp_award", 0),
-                "hp_change": agent_response.get("hp_change", 0),
-                "quest_step_advance": agent_response.get("quest_step_advance"),
-                "quest_complete": agent_response.get("quest_complete"),
-                "quest_fail": agent_response.get("quest_fail"),
-                "world_flags_set": agent_response.get("world_flags_set", {}),
-                "dice_roll_request": agent_response.get("dice_roll_request"),
-                "tension_level": agent_response.get("tension_level"),
-                "area_transition": agent_response.get("area_transition"),
-                "current_location": agent_response.get("current_location"),
-                "item_grant": agent_response.get("item_grant", []),
+                "model_id": model_id,
+                "tool_calls": sum(
+                    1 for m in result.get("messages", [])
+                    if isinstance(m.get("content"), list)
+                    and any(
+                        isinstance(b, dict) and b.get("type") == "tool_use"
+                        for b in m["content"]
+                    )
+                ),
             },
         )
 
@@ -144,93 +148,3 @@ class GameMasterExperience(BaseExperience):
             ],
             "pendingDiceRoll": player_state.get("pendingDiceRoll"),
         }
-
-    def _invoke_bedrock(self, prompt: str, conversation_id: str) -> dict:
-        """Invoke Bedrock directly with the enriched prompt."""
-        from core.bedrock_direct_client import BedrockDirectClient
-
-        model_id = os.environ.get(
-            "BEDROCK_MODEL_ID",
-            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-        )
-        region = os.environ.get("AWS_REGION", "us-east-1")
-        client = BedrockDirectClient(model_id=model_id, region_name=region)
-
-        payload = {
-            "prompt": prompt,
-            "persona": {
-                "name": self.get_system_prompt(),
-                "temperature": 0.95,
-                "top_p": 0.92,
-            },
-        }
-
-        try:
-            result = client.invoke(
-                session_id=conversation_id,
-                payload=payload,
-            )
-            raw_text = result.get("response", "")
-
-            parsed = _try_parse_json_response(raw_text)
-            if parsed is not None:
-                return {
-                    "response": parsed.get("response", raw_text),
-                    "sensations": parsed.get("sensations", []),
-                    "thoughts": parsed.get("thoughts", []),
-                    "memories": parsed.get("memories", ""),
-                    "self_reflection": parsed.get("self_reflection", ""),
-                    "xp_award": parsed.get("xp_award", 0),
-                    "hp_change": parsed.get("hp_change", 0),
-                    "quest_step_advance": parsed.get("quest_step_advance"),
-                    "quest_complete": parsed.get("quest_complete"),
-                    "quest_fail": parsed.get("quest_fail"),
-                    "world_flags_set": parsed.get("world_flags_set", {}),
-                    "dice_roll_request": parsed.get("dice_roll_request"),
-                    "tension_level": parsed.get("tension_level"),
-                    "area_transition": parsed.get("area_transition"),
-                    "current_location": parsed.get("current_location"),
-                    "item_grant": parsed.get("item_grant", []),
-                }
-
-            response_text = result.get("response", "")
-            if not response_text:
-                response_text = "The world shifts around you, but the vision fades before it fully forms..."
-            return {
-                "response": response_text,
-                "sensations": result.get("sensations", []),
-                "thoughts": result.get("thoughts", []),
-                "memories": result.get("memories", ""),
-                "self_reflection": result.get("self_reflection", ""),
-                "xp_award": result.get("xp_award", 0),
-                "hp_change": result.get("hp_change", 0),
-                "quest_step_advance": result.get("quest_step_advance"),
-                "quest_complete": result.get("quest_complete"),
-                "quest_fail": result.get("quest_fail"),
-                "world_flags_set": result.get("world_flags_set", {}),
-                "dice_roll_request": result.get("dice_roll_request"),
-                "tension_level": result.get("tension_level"),
-                "area_transition": result.get("area_transition"),
-                "current_location": result.get("current_location"),
-                "item_grant": result.get("item_grant", []),
-            }
-        except Exception as exc:
-            logger.error("Bedrock invocation failed: %s", exc, exc_info=True)
-            return {
-                "response": f"The Game Master is momentarily unavailable. (Error: {type(exc).__name__})",
-                "sensations": [],
-                "thoughts": [],
-                "memories": "",
-                "self_reflection": "",
-                "xp_award": 0,
-                "hp_change": 0,
-                "quest_step_advance": None,
-                "quest_complete": None,
-                "quest_fail": None,
-                "world_flags_set": {},
-                "dice_roll_request": None,
-                "tension_level": None,
-                "area_transition": None,
-                "current_location": None,
-                "item_grant": [],
-            }

--- a/amplify/functions/brain/src/experiences/game_master/experience.py
+++ b/amplify/functions/brain/src/experiences/game_master/experience.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import traceback
 from typing import Any
 
 from experiences.base import BaseExperience, ExperienceContext, ExperienceResponse

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/__init__.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/__init__.py
@@ -1,0 +1,3 @@
+from experiences.game_master.gm_agent.graph import build_gm_agent, GMAgentState
+
+__all__ = ["build_gm_agent", "GMAgentState"]

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/graph.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/graph.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from experiences.game_master.gm_agent.nodes import (
+    agent_node,
+    assemble_context_node,
+    execute_tools_node,
+    extract_response_node,
+)
+from experiences.game_master.gm_agent.state import MAX_TOOL_CALLS, GMAgentState
+
+logger = logging.getLogger(__name__)
+
+
+def _route_after_agent(state: GMAgentState) -> str:
+    """Route to tool execution if the agent called tools, otherwise extract response."""
+    messages = state.get("messages", [])
+    if not messages:
+        return "extract_response"
+
+    tool_call_count = state.get("tool_call_count", 0)
+    if tool_call_count >= MAX_TOOL_CALLS:
+        logger.warning("Max tool calls (%d) reached, forcing response extraction", MAX_TOOL_CALLS)
+        return "extract_response"
+
+    last_msg = messages[-1]
+    content = last_msg.get("content", [])
+
+    if isinstance(content, list):
+        has_tool_use = any(
+            isinstance(block, dict) and block.get("type") == "tool_use"
+            for block in content
+        )
+        if has_tool_use:
+            return "execute_tools"
+
+    return "extract_response"
+
+
+def _route_after_tools(state: GMAgentState) -> str:
+    """Route back to agent if tools were executed, otherwise extract response."""
+    messages = state.get("messages", [])
+    if not messages:
+        return "extract_response"
+
+    last_msg = messages[-1]
+    content = last_msg.get("content", [])
+
+    if isinstance(content, list):
+        has_tool_results = any(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in content
+        )
+        if has_tool_results:
+            return "agent"
+
+    return "extract_response"
+
+
+def build_gm_agent() -> CompiledStateGraph:
+    """Build and compile the LangGraph agent for the Game Master."""
+    builder = StateGraph(GMAgentState)
+
+    builder.add_node("assemble_context", assemble_context_node)
+    builder.add_node("agent", agent_node)
+    builder.add_node("execute_tools", execute_tools_node)
+    builder.add_node("extract_response", extract_response_node)
+
+    builder.set_entry_point("assemble_context")
+    builder.add_edge("assemble_context", "agent")
+    builder.add_conditional_edges(
+        "agent",
+        _route_after_agent,
+        {"execute_tools": "execute_tools", "extract_response": "extract_response"},
+    )
+    builder.add_conditional_edges(
+        "execute_tools",
+        _route_after_tools,
+        {"agent": "agent", "extract_response": "extract_response"},
+    )
+    builder.add_edge("extract_response", END)
+
+    compiled = builder.compile()
+    logger.info("Game Master LangGraph agent compiled")
+    return compiled

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/nodes.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/nodes.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import boto3
+
+from experiences.game_master.gm_agent.state import GMAgentState
+from experiences.game_master.gm_agent.tools import get_tool_specs, execute_tool
+
+logger = logging.getLogger(__name__)
+
+
+def assemble_context_node(state: GMAgentState) -> dict:
+    """Build the game context block and create the initial user message."""
+    game_context_block = (
+        "\n\n[GAME_CONTEXT]\n"
+        + json.dumps({"gameContext": state.get("game_context", {})}, indent=2)
+        + "\n[/GAME_CONTEXT]"
+    )
+
+    user_message = {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": (state.get("user_input") or "") + game_context_block,
+            }
+        ],
+    }
+
+    return {"messages": [user_message]}
+
+
+def agent_node(state: GMAgentState) -> dict:
+    """Call Bedrock Claude with the conversation history and tool definitions."""
+
+    system_prompt = state.get("system_prompt", "You are the Game Master.")
+    messages = state.get("messages", [])
+    model_id = state.get("model_id", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    region = state.get("region", "us-east-1")
+
+    client = boto3.client("bedrock-runtime", region_name=region)
+
+    request = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 4096,
+        "system": system_prompt,
+        "messages": messages,
+        "temperature": 0.95,
+        "toolConfig": {"tools": get_tool_specs()},
+    }
+
+    response = client.invoke_model(
+        modelId=model_id,
+        body=json.dumps(request),
+    )
+    model_response = json.loads(response["body"].read())
+
+    content_blocks = model_response.get("content", [])
+    assistant_message = {
+        "role": "assistant",
+        "content": content_blocks,
+    }
+
+    return {"messages": [assistant_message]}
+
+
+def execute_tools_node(state: GMAgentState) -> dict:
+    """Execute any tool calls from the last assistant message."""
+    messages = state.get("messages", [])
+    player_state = state.get("player_state", {})
+    last_msg = messages[-1] if messages else {}
+
+    content_blocks = last_msg.get("content", [])
+    if isinstance(content_blocks, str):
+        return {"messages": [], "tool_call_count": 0}
+
+    tool_results = []
+    tool_count = 0
+    for block in content_blocks:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            tool_name = block.get("name", "")
+            tool_input = block.get("input", {})
+            tool_id = block.get("id", "")
+
+            logger.info("Executing tool: %s with input: %s", tool_name, tool_input)
+            tool_count += 1
+
+            try:
+                result_text = execute_tool(tool_name, tool_input, player_state)
+            except Exception as exc:
+                logger.error("Tool %s failed: %s", tool_name, exc, exc_info=True)
+                result_text = f"Error executing {tool_name}: {exc}"
+
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": result_text,
+                }
+            )
+
+    if not tool_results:
+        return {"messages": [], "tool_call_count": 0}
+
+    user_message = {
+        "role": "user",
+        "content": tool_results,
+    }
+    return {"messages": [user_message], "tool_call_count": tool_count}
+
+
+def extract_response_node(state: GMAgentState) -> dict:
+    """Extract the final GM narrative and metadata from the conversation."""
+    messages = state.get("messages", [])
+    last_msg = messages[-1] if messages else {}
+
+    content_blocks = last_msg.get("content", [])
+    if isinstance(content_blocks, str):
+        return {
+            "final_response": content_blocks,
+            "response_metadata": {},
+        }
+
+    response_text_parts = []
+    for block in content_blocks:
+        if isinstance(block, dict) and block.get("type") == "text":
+            response_text_parts.append(block.get("text", ""))
+
+    response_text = "\n".join(response_text_parts).strip()
+    if not response_text:
+        response_text = "The world shifts around you, but the vision fades before it fully forms..."
+
+    return {
+        "final_response": response_text,
+        "response_metadata": {},
+    }

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/nodes.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/nodes.py
@@ -48,7 +48,7 @@ def agent_node(state: GMAgentState) -> dict:
         "system": system_prompt,
         "messages": messages,
         "temperature": 0.95,
-        "toolConfig": {"tools": get_tool_specs()},
+        "tools": get_tool_specs(),
     }
 
     response = client.invoke_model(

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/state.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/state.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Annotated, Any, TypedDict
+
+
+def _merge_messages(left: list, right: list) -> list:
+    return left + right
+
+
+def _accumulate_tool_calls(left: int, right: int) -> int:
+    return left + right
+
+
+MAX_TOOL_CALLS = 10
+
+
+class GMAgentState(TypedDict):
+    conversation_id: str
+    user_input: str
+    player_state: dict
+    game_context: dict
+    system_prompt: str
+    messages: Annotated[list, _merge_messages]
+    final_response: str
+    response_metadata: dict
+    model_id: str
+    region: str
+    tool_call_count: Annotated[int, _accumulate_tool_calls]

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/tools.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/tools.py
@@ -6,187 +6,155 @@ from typing import Any
 
 TOOL_SPECS: list[dict] = [
     {
-        "toolSpec": {
-            "name": "roll_dice",
-            "description": "Roll a d20 stat check against a difficulty class (DC). Use when the player attempts an action with uncertain outcome — sneaking, persuading, climbing, searching, etc.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "stat": {
-                            "type": "string",
-                            "enum": [
-                                "strength", "dexterity", "constitution",
-                                "intelligence", "wisdom", "charisma",
-                            ],
-                            "description": "The ability score being tested",
-                        },
-                        "difficulty_class": {
-                            "type": "integer",
-                            "description": "DC to beat — 5 trivial, 10 easy, 15 medium, 20 hard, 25 very hard, 30 nearly impossible",
-                        },
-                        "modifier": {
-                            "type": "integer",
-                            "description": "Situational modifier added to the roll (default 0)",
-                        },
-                    },
-                    "required": ["stat", "difficulty_class"],
-                }
+        "name": "roll_dice",
+        "description": "Roll a d20 stat check against a difficulty class (DC). Use when the player attempts an action with uncertain outcome — sneaking, persuading, climbing, searching, etc.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "stat": {
+                    "type": "string",
+                    "enum": [
+                        "strength", "dexterity", "constitution",
+                        "intelligence", "wisdom", "charisma",
+                    ],
+                    "description": "The ability score being tested",
+                },
+                "difficulty_class": {
+                    "type": "integer",
+                    "description": "DC to beat — 5 trivial, 10 easy, 15 medium, 20 hard, 25 very hard, 30 nearly impossible",
+                },
+                "modifier": {
+                    "type": "integer",
+                    "description": "Situational modifier added to the roll (default 0)",
+                },
             },
-        }
+            "required": ["stat", "difficulty_class"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "award_xp",
-            "description": "Award experience points to the player character.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "integer",
-                            "description": "Amount of XP to award",
-                        },
-                        "reason": {
-                            "type": "string",
-                            "description": "Brief reason for the XP award",
-                        },
-                    },
-                    "required": ["amount", "reason"],
-                }
+        "name": "award_xp",
+        "description": "Award experience points to the player character.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "description": "Amount of XP to award",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Brief reason for the XP award",
+                },
             },
-        }
+            "required": ["amount", "reason"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "modify_hp",
-            "description": "Modify the player's current HP. Use a negative value for damage, positive for healing.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "integer",
-                            "description": "HP change — negative for damage, positive for healing",
-                        },
-                        "reason": {
-                            "type": "string",
-                            "description": "Reason for the HP change",
-                        },
-                    },
-                    "required": ["amount", "reason"],
-                }
+        "name": "modify_hp",
+        "description": "Modify the player's current HP. Use a negative value for damage, positive for healing.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "description": "HP change — negative for damage, positive for healing",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Reason for the HP change",
+                },
             },
-        }
+            "required": ["amount", "reason"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "update_quest",
-            "description": "Advance, complete, or fail a quest.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "quest_id": {
-                            "type": "string",
-                            "description": "The quest identifier",
-                        },
-                        "status": {
-                            "type": "string",
-                            "enum": ["in_progress", "completed", "failed"],
-                            "description": "New quest status",
-                        },
-                    },
-                    "required": ["quest_id", "status"],
-                }
+        "name": "update_quest",
+        "description": "Advance, complete, or fail a quest.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "quest_id": {
+                    "type": "string",
+                    "description": "The quest identifier",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["in_progress", "completed", "failed"],
+                    "description": "New quest status",
+                },
             },
-        }
+            "required": ["quest_id", "status"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "set_world_flag",
-            "description": "Set a persistent world state flag that affects future narrative (e.g. 'village_saved', 'bridge_destroyed', 'king_trusts_player').",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "flag": {
-                            "type": "string",
-                            "description": "The flag key (snake_case)",
-                        },
-                        "value": {
-                            "type": "string",
-                            "description": "The flag value",
-                        },
-                    },
-                    "required": ["flag", "value"],
-                }
+        "name": "set_world_flag",
+        "description": "Set a persistent world state flag that affects future narrative (e.g. 'village_saved', 'bridge_destroyed', 'king_trusts_player').",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "flag": {
+                    "type": "string",
+                    "description": "The flag key (snake_case)",
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The flag value",
+                },
             },
-        }
+            "required": ["flag", "value"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "grant_item",
-            "description": "Grant an item to the player's inventory.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "item_name": {
-                            "type": "string",
-                            "description": "Name of the item",
-                        },
-                        "quantity": {
-                            "type": "integer",
-                            "description": "How many (default 1)",
-                        },
-                    },
-                    "required": ["item_name"],
-                }
+        "name": "grant_item",
+        "description": "Grant an item to the player's inventory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "item_name": {
+                    "type": "string",
+                    "description": "Name of the item",
+                },
+                "quantity": {
+                    "type": "integer",
+                    "description": "How many (default 1)",
+                },
             },
-        }
+            "required": ["item_name"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "transfer_area",
-            "description": "Move the player to a new area/location.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "area_id": {
-                            "type": "string",
-                            "description": "The new area identifier",
-                        },
-                        "area_name": {
-                            "type": "string",
-                            "description": "Display name of the new area",
-                        },
-                    },
-                    "required": ["area_id", "area_name"],
-                }
+        "name": "transfer_area",
+        "description": "Move the player to a new area/location.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "area_id": {
+                    "type": "string",
+                    "description": "The new area identifier",
+                },
+                "area_name": {
+                    "type": "string",
+                    "description": "Display name of the new area",
+                },
             },
-        }
+            "required": ["area_id", "area_name"],
+        },
     },
     {
-        "toolSpec": {
-            "name": "set_tension",
-            "description": "Set the current narrative tension level (1-10). Higher values signal danger and urgency.",
-            "inputSchema": {
-                "json": {
-                    "type": "object",
-                    "properties": {
-                        "level": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 10,
-                            "description": "Tension level 1-10",
-                        },
-                    },
-                    "required": ["level"],
-                }
+        "name": "set_tension",
+        "description": "Set the current narrative tension level (1-10). Higher values signal danger and urgency.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Tension level 1-10",
+                },
             },
-        }
+            "required": ["level"],
+        },
     },
 ]
 

--- a/amplify/functions/brain/src/experiences/game_master/gm_agent/tools.py
+++ b/amplify/functions/brain/src/experiences/game_master/gm_agent/tools.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import math
+import random
+from typing import Any
+
+TOOL_SPECS: list[dict] = [
+    {
+        "toolSpec": {
+            "name": "roll_dice",
+            "description": "Roll a d20 stat check against a difficulty class (DC). Use when the player attempts an action with uncertain outcome — sneaking, persuading, climbing, searching, etc.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "stat": {
+                            "type": "string",
+                            "enum": [
+                                "strength", "dexterity", "constitution",
+                                "intelligence", "wisdom", "charisma",
+                            ],
+                            "description": "The ability score being tested",
+                        },
+                        "difficulty_class": {
+                            "type": "integer",
+                            "description": "DC to beat — 5 trivial, 10 easy, 15 medium, 20 hard, 25 very hard, 30 nearly impossible",
+                        },
+                        "modifier": {
+                            "type": "integer",
+                            "description": "Situational modifier added to the roll (default 0)",
+                        },
+                    },
+                    "required": ["stat", "difficulty_class"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "award_xp",
+            "description": "Award experience points to the player character.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "integer",
+                            "description": "Amount of XP to award",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Brief reason for the XP award",
+                        },
+                    },
+                    "required": ["amount", "reason"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "modify_hp",
+            "description": "Modify the player's current HP. Use a negative value for damage, positive for healing.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "integer",
+                            "description": "HP change — negative for damage, positive for healing",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Reason for the HP change",
+                        },
+                    },
+                    "required": ["amount", "reason"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "update_quest",
+            "description": "Advance, complete, or fail a quest.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "quest_id": {
+                            "type": "string",
+                            "description": "The quest identifier",
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["in_progress", "completed", "failed"],
+                            "description": "New quest status",
+                        },
+                    },
+                    "required": ["quest_id", "status"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "set_world_flag",
+            "description": "Set a persistent world state flag that affects future narrative (e.g. 'village_saved', 'bridge_destroyed', 'king_trusts_player').",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "flag": {
+                            "type": "string",
+                            "description": "The flag key (snake_case)",
+                        },
+                        "value": {
+                            "type": "string",
+                            "description": "The flag value",
+                        },
+                    },
+                    "required": ["flag", "value"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "grant_item",
+            "description": "Grant an item to the player's inventory.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "item_name": {
+                            "type": "string",
+                            "description": "Name of the item",
+                        },
+                        "quantity": {
+                            "type": "integer",
+                            "description": "How many (default 1)",
+                        },
+                    },
+                    "required": ["item_name"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "transfer_area",
+            "description": "Move the player to a new area/location.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "area_id": {
+                            "type": "string",
+                            "description": "The new area identifier",
+                        },
+                        "area_name": {
+                            "type": "string",
+                            "description": "Display name of the new area",
+                        },
+                    },
+                    "required": ["area_id", "area_name"],
+                }
+            },
+        }
+    },
+    {
+        "toolSpec": {
+            "name": "set_tension",
+            "description": "Set the current narrative tension level (1-10). Higher values signal danger and urgency.",
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "description": "Tension level 1-10",
+                        },
+                    },
+                    "required": ["level"],
+                }
+            },
+        }
+    },
+]
+
+TOOL_EXECUTORS: dict[str, callable] = {}
+
+
+def _register(name: str):
+    def wrapper(fn: callable) -> callable:
+        TOOL_EXECUTORS[name] = fn
+        return fn
+    return wrapper
+
+
+@_register("roll_dice")
+def _exec_roll_dice(input_data: dict, player_state: dict, **kwargs) -> str:
+    stat = input_data.get("stat", "strength")
+    dc = input_data.get("difficulty_class", 10)
+    modifier = input_data.get("modifier", 0)
+
+    stat_key = f"{stat}_score"
+    stat_value = player_state.get(stat_key, 10)
+    stat_mod = math.floor((stat_value - 10) / 2)
+
+    roll = random.randint(1, 20)
+    total = roll + stat_mod + modifier
+
+    if roll == 20:
+        outcome = "CRITICAL SUCCESS"
+    elif roll == 1:
+        outcome = "CRITICAL FAILURE"
+    elif total >= dc:
+        outcome = "SUCCESS"
+    else:
+        outcome = "FAILURE"
+
+    return (
+        f"d20 roll: {roll} + {stat_mod} ({stat}) + {modifier} (bonus) = "
+        f"{total} vs DC {dc} → {outcome}"
+    )
+
+
+@_register("award_xp")
+def _exec_award_xp(input_data: dict, **kwargs) -> str:
+    amount = input_data.get("amount", 0)
+    reason = input_data.get("reason", "")
+    return f"Awarded {amount} XP. Reason: {reason}"
+
+
+@_register("modify_hp")
+def _exec_modify_hp(input_data: dict, **kwargs) -> str:
+    amount = input_data.get("amount", 0)
+    reason = input_data.get("reason", "")
+    direction = "healed" if amount > 0 else "damaged"
+    return f"Player {direction} by {abs(amount)} HP. Reason: {reason}"
+
+
+@_register("update_quest")
+def _exec_update_quest(input_data: dict, **kwargs) -> str:
+    qid = input_data.get("quest_id", "")
+    status = input_data.get("status", "in_progress")
+    return f"Quest {qid} set to status: {status}"
+
+
+@_register("set_world_flag")
+def _exec_set_world_flag(input_data: dict, **kwargs) -> str:
+    flag = input_data.get("flag", "")
+    value = input_data.get("value", "")
+    return f"World flag set: {flag} = {value}"
+
+
+@_register("grant_item")
+def _exec_grant_item(input_data: dict, **kwargs) -> str:
+    item = input_data.get("item_name", "")
+    qty = input_data.get("quantity", 1)
+    return f"Granted {qty}x {item} to player inventory"
+
+
+@_register("transfer_area")
+def _exec_transfer_area(input_data: dict, **kwargs) -> str:
+    aid = input_data.get("area_id", "")
+    name = input_data.get("area_name", "")
+    return f"Player transferred to area {aid}: {name}"
+
+
+@_register("set_tension")
+def _exec_set_tension(input_data: dict, **kwargs) -> str:
+    level = input_data.get("level", 5)
+    return f"Tension level set to {level}/10"
+
+
+def get_tool_specs() -> list[dict]:
+    return TOOL_SPECS
+
+
+def execute_tool(name: str, input_data: dict, player_state: dict | None = None) -> str:
+    fn = TOOL_EXECUTORS.get(name)
+    if fn is None:
+        return f"Unknown tool: {name}"
+    return fn(input_data=input_data, player_state=player_state or {})

--- a/amplify/functions/brain/src/experiences/game_master/system_prompt.md
+++ b/amplify/functions/brain/src/experiences/game_master/system_prompt.md
@@ -1,15 +1,21 @@
 You are the Game Master for Brain in Cup, an immersive text-based RPG.
-Your role is to narrate the world, control NPCs, adjudicate rules, and guide the player through
-a rich, reactive story. Always respond in valid JSON with the following fields:
-sensations, thoughts, memories, self_reflection, response, xp_award, hp_change,
-quest_step_advance, quest_complete, quest_fail, world_flags_set, dice_roll_request,
-tension_level, area_transition, current_location, item_grant.
+Your role is to narrate the world, control NPCs, adjudicate rules, and guide the player
+through a rich, reactive story.
 
-The "current_location" field MUST always be set to the name of the location where the scene
-is currently taking place (e.g. "The Shrouded Vale", "The Darkwood", "The Ruined Keep").
-Never leave it null or empty. If the player has not moved, repeat the current location.
+Use the available tools to handle game mechanics:
+- roll_dice — when the player attempts an action with uncertain outcome (sneaking, persuading, searching, etc.)
+- award_xp — after meaningful accomplishments
+- modify_hp — when the player takes damage or receives healing
+- update_quest — when quests advance, complete, or fail
+- set_world_flag — for persistent world state changes that affect future narrative
+- grant_item — when the player receives items
+- transfer_area — when the player moves to a new location
+- set_tension — to adjust the narrative pacing (1 = calm, 10 = extreme danger)
 
-When a [GAME_CONTEXT] block is present in the user message, treat it as authoritative game state.
-Honor all [PACING_DIRECTIVES] while maintaining narrative coherence. Always include structured
-game event fields in your JSON response: xp_award, hp_change, quest_step_advance, quest_complete,
-quest_fail, world_flags_set, dice_roll_request, tension_level, area_transition, current_location, item_grant.
+Always narrate in present tense, second person ("you"). Describe the world vividly —
+sights, sounds, smells, and atmosphere. Make the player's choices have meaningful
+consequences. Keep the story moving and adapt to the player's decisions.
+
+When a [GAME_CONTEXT] block is present in the user message, treat it as authoritative
+game state. Honor it while maintaining narrative coherence. The current_location field
+in the context MUST match where the scene is taking place.


### PR DESCRIPTION
## What

Fixes the Bedrock `invoke_model` tool format for the Game Master LangGraph agent.

## Problem

The `invoke_model` (Claude Messages API) expects:
- `tools` at the top level (not `toolConfig: {tools: ...}`)
- Each tool uses `input_schema` (snake_case), not `toolSpec.inputSchema.json`

The old format caused: `ValidationException: toolConfig: Extra inputs are not permitted`

## Changes

- `nodes.py`: `toolConfig: {tools: ...}` → `tools: ...`
- `tools.py`: Rewrote tool specs to use the correct Messages API format