### PR TITLE
feat(menu): full menu with delete account and clear chat for Brain

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -2,6 +2,7 @@ import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { brain } from './functions/brain/resource';
+import { deleteAccount } from './functions/delete-account/resource';
 import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { EventSourceMapping, StartingPosition } from 'aws-cdk-lib/aws-lambda';
 import { FunctionUrlAuthType, HttpMethod, InvokeMode } from 'aws-cdk-lib/aws-lambda';
@@ -99,6 +100,7 @@ const backend = defineBackend({
   auth,
   data,
   brain,
+  deleteAccount,
 });
 
 const stack = backend.stack;
@@ -208,6 +210,10 @@ const responseTable = backend.data.resources.tables['BrainResponse'];
 const characterTable = backend.data.resources.tables['GameMasterCharacter'];
 const questStepTable = backend.data.resources.tables['GameMasterQuestStep'];
 const adventureTable = backend.data.resources.tables['GameMasterAdventure'];
+const playerChoiceTable = backend.data.resources.tables['GameMasterPlayerChoice'];
+const playerStateTable = backend.data.resources.tables['PlayerState'];
+const worldStateTable = backend.data.resources.tables['WorldState'];
+const activeQuestTable = backend.data.resources.tables['ActiveQuest'];
 
 const brainLambda = backend.brain.resources.lambda as import('aws-cdk-lib').aws_lambda.Function;
 
@@ -305,6 +311,49 @@ brainLambda.addToRolePolicy(new PolicyStatement({
   resources: [
     `arn:aws:appsync:${stack.region}:${stack.account}:apis/${backend.data.resources.cfnResources.cfnGraphqlApi.attrApiId}/types/*`,
   ],
+  effect: Effect.ALLOW,
+}));
+
+// ─── Delete Account Function ─────────────────────────────────────────────────
+const deleteAccountLambda = backend.deleteAccount.resources.lambda as import('aws-cdk-lib').aws_lambda.Function;
+
+deleteAccountLambda.addEnvironment('USER_POOL_ID', backend.auth.resources.userPool.userPoolId);
+deleteAccountLambda.addEnvironment('CONVERSATION_TABLE_NAME', conversationTable.tableName);
+deleteAccountLambda.addEnvironment('MESSAGE_TABLE_NAME', messageTable.tableName);
+deleteAccountLambda.addEnvironment('RESPONSE_TABLE_NAME', responseTable.tableName);
+deleteAccountLambda.addEnvironment('ADVENTURE_TABLE_NAME', adventureTable.tableName);
+deleteAccountLambda.addEnvironment('CHARACTER_TABLE_NAME', characterTable.tableName);
+deleteAccountLambda.addEnvironment('QUEST_STEP_TABLE_NAME', questStepTable.tableName);
+deleteAccountLambda.addEnvironment('PLAYER_CHOICE_TABLE_NAME', playerChoiceTable.tableName);
+deleteAccountLambda.addEnvironment('PLAYER_STATE_TABLE_NAME', playerStateTable.tableName);
+deleteAccountLambda.addEnvironment('WORLD_STATE_TABLE_NAME', worldStateTable.tableName);
+deleteAccountLambda.addEnvironment('ACTIVE_QUEST_TABLE_NAME', activeQuestTable.tableName);
+
+deleteAccountLambda.addToRolePolicy(new PolicyStatement({
+  actions: ['cognito-idp:AdminDeleteUser'],
+  resources: [backend.auth.resources.userPool.userPoolArn],
+  effect: Effect.ALLOW,
+}));
+
+const dataTables = [
+  conversationTable,
+  messageTable,
+  responseTable,
+  characterTable,
+  questStepTable,
+  adventureTable,
+  playerChoiceTable,
+  playerStateTable,
+  worldStateTable,
+  activeQuestTable,
+];
+
+deleteAccountLambda.addToRolePolicy(new PolicyStatement({
+  actions: ['dynamodb:Scan', 'dynamodb:DeleteItem'],
+  resources: dataTables.flatMap((table) => [
+    `arn:aws:dynamodb:${stack.region}:${stack.account}:table/${table.tableName}`,
+    `arn:aws:dynamodb:${stack.region}:${stack.account}:table/${table.tableName}/*`,
+  ]),
   effect: Effect.ALLOW,
 }));
 

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,5 +1,6 @@
 import { defineData, a } from '@aws-amplify/backend';
 import { ClientSchema } from '@aws-amplify/backend';
+import { deleteAccount } from '../functions/delete-account/resource';
 
 const schema = a.schema({
   Conversation: a.model({
@@ -231,6 +232,12 @@ const schema = a.schema({
   })
     .secondaryIndexes((index) => [index('playerStateId')])
     .authorization(allow => [allow.owner(), allow.groups(['Admins'])]),
+
+  deleteAccount: a
+    .mutation()
+    .authorization((allow) => [allow.authenticated()])
+    .handler(a.handler.function(deleteAccount))
+    .returns(a.boolean()),
 });
 
 export const data = defineData({

--- a/amplify/functions/delete-account/handler.ts
+++ b/amplify/functions/delete-account/handler.ts
@@ -1,0 +1,85 @@
+import type { Schema } from '../../data/resource';
+import AWS from 'aws-sdk';
+
+type DeleteAccountHandler = Schema['deleteAccount']['functionHandler'];
+
+const DATA_TABLE_ENV_KEYS = [
+  'CONVERSATION_TABLE_NAME',
+  'MESSAGE_TABLE_NAME',
+  'RESPONSE_TABLE_NAME',
+  'ADVENTURE_TABLE_NAME',
+  'CHARACTER_TABLE_NAME',
+  'QUEST_STEP_TABLE_NAME',
+  'PLAYER_CHOICE_TABLE_NAME',
+  'PLAYER_STATE_TABLE_NAME',
+  'WORLD_STATE_TABLE_NAME',
+  'ACTIVE_QUEST_TABLE_NAME',
+];
+
+const getIdentity = (event: unknown) => {
+  const request = (event as { request?: { jwt?: { sub?: string; username?: string; claims?: Record<string, unknown> } } })
+    .request ?? {};
+  const jwt = request.jwt ?? {};
+  const claims = jwt.claims ?? {};
+  const username = jwt.username ?? (claims.username as string | undefined);
+  const sub = jwt.sub ?? (claims.sub as string | undefined);
+  return { username, sub };
+};
+
+const deleteDataForOwner = async (sub: string): Promise<void> => {
+  const ddb = new AWS.DynamoDB({ region: process.env.AWS_REGION });
+
+  for (const envKey of DATA_TABLE_ENV_KEYS) {
+    const tableName = process.env[envKey];
+    if (!tableName) continue;
+
+    let exclusiveStartKey: AWS.DynamoDB.Key | undefined;
+    let deleted = 0;
+
+    do {
+      const result = await ddb
+        .scan({
+          TableName: tableName,
+          FilterExpression: '#owner = :sub',
+          ExpressionAttributeNames: { '#owner': 'owner' },
+          ExpressionAttributeValues: { ':sub': { S: sub } },
+          ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
+        })
+        .promise();
+
+      exclusiveStartKey = result.LastEvaluatedKey as AWS.DynamoDB.Key | undefined;
+
+      for (const item of result.Items ?? []) {
+        if (!item.id) continue;
+        await ddb
+          .deleteItem({ TableName: tableName, Key: { id: item.id } })
+          .promise();
+        deleted += 1;
+      }
+    } while (exclusiveStartKey);
+
+    console.log(`deleteAccount: removed ${deleted} items from ${tableName}`);
+  }
+};
+
+export const handler: DeleteAccountHandler = async (event) => {
+  const { username, sub } = getIdentity(event);
+
+  if (!username || !sub) {
+    throw new Error('Unable to identify the authenticated user.');
+  }
+
+  const userPoolId = process.env.USER_POOL_ID;
+  if (!userPoolId) {
+    throw new Error('User pool is not configured.');
+  }
+
+  // 1. Delete the Cognito user so they can no longer sign in.
+  const cognito = new AWS.CognitoIdentityServiceProvider({ region: process.env.AWS_REGION });
+  await cognito.adminDeleteUser({ UserPoolId: userPoolId, Username: username }).promise();
+
+  // 2. Remove the user's data across all tables.
+  await deleteDataForOwner(sub);
+
+  return true;
+};

--- a/amplify/functions/delete-account/resource.ts
+++ b/amplify/functions/delete-account/resource.ts
@@ -1,0 +1,6 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const deleteAccount = defineFunction({
+  name: 'delete-account',
+  timeoutSeconds: 60,
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import { isTestModeEnabled } from './utils/testMode';
 import { streamAgentMessage, type AguiEvent } from './utils/aguiStream';
 import { MessageBubble, type Message } from './components/MessageBubble';
+import DeleteAccountModal from './components/DeleteAccountModal';
 const dataClient = generateClient<Schema>();
 
 type AdventureRecord = Schema['GameMasterAdventure']['type'];
@@ -421,6 +422,9 @@ function App() {
   );
   const [expandedMessageIndex, setExpandedMessageIndex] = useState<number | null>(null); // Track which message's details are shown
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] = useState(false);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
   const [conversationListRefreshKey, setConversationListRefreshKey] = useState(0);
   const [draggingConversationId, setDraggingConversationId] = useState<string | null>(null);
   const [isTrashDragOver, setIsTrashDragOver] = useState(false);
@@ -2264,6 +2268,34 @@ function App() {
     }
   };
 
+  const clearLocalAccountData = () => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  };
+
+  const handleDeleteAccount = async () => {
+    setIsDeletingAccount(true);
+    setDeleteAccountError(null);
+    try {
+      if (!isTestModeEnabled()) {
+        const result = await dataClient.mutations.deleteAccount();
+        if (result.errors?.length) {
+          throw new Error(result.errors[0]?.message ?? 'Failed to delete account.');
+        }
+      }
+      clearLocalAccountData();
+      await signOut();
+      window.location.reload();
+    } catch (error) {
+      console.error('Error deleting account:', error);
+      setDeleteAccountError(
+        error instanceof Error && error.message ? error.message : 'Something went wrong. Please try again.'
+      );
+      setIsDeletingAccount(false);
+    }
+  };
+
   const handleCharacterCreationComplete = useCallback(async (characterData: CharacterCreationInput) => {
     if (!conversationId) {
       // Character creation is only reachable in Game Master mode, so the
@@ -2528,39 +2560,19 @@ function App() {
                   <div ref={profileMenuRef} className="relative z-40">
                     <button
                       type="button"
-                      onClick={() => { void handleSidebarDeleteAction(); }}
+                      onClick={() => setIsProfileMenuOpen((prev) => !prev)}
                       onDragOver={handleTrashDragOver}
                       onDragLeave={handleTrashDragLeave}
                       onDrop={handleTrashDrop}
-                      className={`retro-icon-button retro-tooltip-trigger mb-2 h-10 w-10 rounded-xl border flex items-center justify-center transition-all duration-200 ${
-                        isTrashDragOver
-                          ? 'border-brand-status-error/70 bg-brand-status-error/28 text-brand-status-error scale-[1.16] shadow-[0_12px_26px_rgba(239,68,68,0.34)]'
-                          : 'border-brand-surface-border/50 bg-brand-surface-secondary/60 text-brand-text-primary hover:border-brand-surface-border/70 hover:bg-brand-surface-secondary/75'
-                      } disabled:cursor-not-allowed disabled:opacity-45`}
-                      aria-label="Delete current chat"
-                      disabled={!conversationId}
-                      data-tooltip={conversationId ? 'Delete current chat' : 'No chat to delete'}
-                      data-tooltip-position="right"
-                    >
-                      <svg
-                        className="h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 7h12M9 7V5a3 3 0 016 0v2m-7 4v6m4-6v6m4-6v6M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
-                      </svg>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setIsProfileMenuOpen((prev) => !prev)}
                       className={`retro-icon-button retro-tooltip-trigger h-10 w-10 rounded-xl border flex items-center justify-center transition-all duration-200 ${
-                        isProfileMenuOpen
-                          ? 'border-brand-accent-primary/65 bg-brand-accent-primary/18 text-brand-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.16)]'
+                        isProfileMenuOpen || isTrashDragOver
+                          ? isTrashDragOver
+                            ? 'border-brand-status-error/70 bg-brand-status-error/28 text-brand-status-error scale-[1.16] shadow-[0_12px_26px_rgba(239,68,68,0.34)]'
+                            : 'border-brand-accent-primary/65 bg-brand-accent-primary/18 text-brand-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.16)]'
                           : 'border-brand-surface-border/50 bg-brand-surface-secondary/60 text-brand-text-primary hover:border-brand-surface-border/70 hover:bg-brand-surface-elevated/70'
                       }`}
-                      aria-label="Open profile menu"
-                      data-tooltip="Account menu"
+                      aria-label="Open menu"
+                      data-tooltip="Menu"
                       data-tooltip-position="right"
                     >
                       <span className="relative flex items-center justify-center" aria-hidden="true">
@@ -2574,11 +2586,24 @@ function App() {
                     </button>
 
                     {isProfileMenuOpen && (
-                      <div className="retro-dropdown absolute bottom-0 left-[calc(100%+10px)] z-[90] min-w-[220px] rounded-2xl border border-brand-surface-border/50 bg-brand-surface-elevated/95 p-2 shadow-glass-lg backdrop-blur-xl">
+                      <div className="retro-dropdown absolute bottom-0 left-[calc(100%+10px)] z-[90] min-w-[230px] rounded-2xl border border-brand-surface-border/50 bg-brand-surface-elevated/95 p-2 shadow-glass-lg backdrop-blur-xl">
                         <div className="px-2 py-1.5">
                           <p className="truncate text-xs font-medium text-brand-text-primary">{websiteUserProfile.displayName}</p>
                           <p className="truncate text-[11px] text-brand-text-muted">{websiteUserProfile.email}</p>
                         </div>
+                        <div className="my-1.5 h-px bg-brand-surface-border/50" />
+                        <button
+                          type="button"
+                          onClick={() => { void handleSidebarDeleteAction(); }}
+                          disabled={!conversationId}
+                          className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-status-error disabled:opacity-45 disabled:cursor-not-allowed"
+                        >
+                          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 7h12M9 7V5a3 3 0 016 0v2m-7 4v6m4-6v6m4-6v6M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
+                          </svg>
+                          Delete current chat
+                        </button>
+                        <div className="my-1.5 h-px bg-brand-surface-border/50" />
                         <button
                           type="button"
                           onClick={handleSignOut}
@@ -2591,14 +2616,16 @@ function App() {
                         </button>
                         <button
                           type="button"
-                          onClick={() => { void handleSidebarDeleteAction(); }}
-                          disabled={!conversationId}
-                          className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-status-error disabled:opacity-45 disabled:cursor-not-allowed"
+                          onClick={() => {
+                            setIsProfileMenuOpen(false);
+                            setIsDeleteAccountModalOpen(true);
+                          }}
+                          className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-status-error"
                         >
                           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 7h12M9 7V5a3 3 0 016 0v2m-7 4v6m4-6v6m4-6v6M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                           </svg>
-                          Delete chat
+                          Delete account
                         </button>
                       </div>
                     )}
@@ -3202,6 +3229,14 @@ function App() {
 
       {/* Install Prompt */}
       <InstallPrompt />
+
+      <DeleteAccountModal
+        isOpen={isDeleteAccountModalOpen}
+        isDeleting={isDeletingAccount}
+        error={deleteAccountError}
+        onClose={() => setIsDeleteAccountModalOpen(false)}
+        onConfirm={() => { void handleDeleteAccount(); }}
+      />
 
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2233,11 +2233,11 @@ function App() {
   }, [conversationId, effectivePersonality]);
 
   const handleTrashDragOver = useCallback((event: React.DragEvent<HTMLButtonElement>) => {
-    if (!draggingConversationId) return;
+    if (!draggingConversationId || draggingConversationId === brainConversationId) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
     setIsTrashDragOver(true);
-  }, [draggingConversationId]);
+  }, [draggingConversationId, brainConversationId]);
 
   const handleTrashDragLeave = useCallback(() => {
     setIsTrashDragOver(false);
@@ -2251,12 +2251,53 @@ function App() {
       || draggingConversationId
       || '';
     if (droppedConversationId) {
+      if (droppedConversationId === brainConversationId) {
+        setIsTrashDragOver(false);
+        setDraggingConversationId(null);
+        return;
+      }
       void deleteConversationById(droppedConversationId);
     } else {
       setIsTrashDragOver(false);
       setDraggingConversationId(null);
     }
-  }, [deleteConversationById, draggingConversationId]);
+  }, [deleteConversationById, draggingConversationId, brainConversationId]);
+
+  const handleClearBrainChat = async () => {
+    if (!conversationId || effectivePersonality !== 'brain') return;
+    setIsProfileMenuOpen(false);
+
+    try {
+      if (!isTestModeEnabled()) {
+        const { data: brainResponses } = await dataClient.models.BrainResponse.list({
+          filter: { conversationId: { eq: conversationId } },
+        });
+        for (const response of brainResponses ?? []) {
+          if (response.id) {
+            await dataClient.models.BrainResponse.delete({ id: response.id });
+          }
+        }
+
+        const { data: conversationMessages } = await dataClient.models.Message.list({
+          filter: { conversationId: { eq: conversationId } },
+        });
+        for (const message of conversationMessages ?? []) {
+          if (message.id) {
+            await dataClient.models.Message.delete({ id: message.id });
+          }
+        }
+      }
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(getMessagesCacheKey(conversationId));
+      }
+      setMessages([]);
+      setIsWaitingForResponse(false);
+      setConversationListRefreshKey((prev) => prev + 1);
+    } catch (error) {
+      console.error('Error clearing chat:', error);
+    }
+  };
 
 
   const handleSignOut = async () => {
@@ -2592,17 +2633,31 @@ function App() {
                           <p className="truncate text-[11px] text-brand-text-muted">{websiteUserProfile.email}</p>
                         </div>
                         <div className="my-1.5 h-px bg-brand-surface-border/50" />
-                        <button
-                          type="button"
-                          onClick={() => { void handleSidebarDeleteAction(); }}
-                          disabled={!conversationId}
-                          className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-status-error disabled:opacity-45 disabled:cursor-not-allowed"
-                        >
-                          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 7h12M9 7V5a3 3 0 016 0v2m-7 4v6m4-6v6m4-6v6M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
-                          </svg>
-                          Delete current chat
-                        </button>
+                        {isGameMasterMode ? (
+                          <button
+                            type="button"
+                            onClick={() => { void handleSidebarDeleteAction(); }}
+                            disabled={!conversationId}
+                            className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-status-error disabled:opacity-45 disabled:cursor-not-allowed"
+                          >
+                            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 7h12M9 7V5a3 3 0 016 0v2m-7 4v6m4-6v6m4-6v6M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
+                            </svg>
+                            Delete current chat
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => { void handleClearBrainChat(); }}
+                            disabled={!conversationId || messages.length === 0}
+                            className="retro-dropdown-item flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-text-primary disabled:opacity-45 disabled:cursor-not-allowed"
+                          >
+                            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                            </svg>
+                            Clear chat
+                          </button>
+                        )}
                         <div className="my-1.5 h-px bg-brand-surface-border/50" />
                         <button
                           type="button"

--- a/src/components/DeleteAccountModal.tsx
+++ b/src/components/DeleteAccountModal.tsx
@@ -1,0 +1,60 @@
+interface DeleteAccountModalProps {
+  isOpen: boolean;
+  isDeleting: boolean;
+  error: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function DeleteAccountModal({
+  isOpen,
+  isDeleting,
+  error,
+  onClose,
+  onConfirm,
+}: DeleteAccountModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-md flex items-center justify-center z-[100] p-4 animate-fade-in"
+      onClick={isDeleting ? undefined : onClose}
+    >
+      <div
+        className="bg-brand-surface-elevated border border-brand-surface-border rounded-2xl shadow-2xl max-w-md w-full p-6 animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-bold text-brand-text-primary mb-2">Delete account?</h3>
+        <p className="text-sm text-brand-text-muted mb-6 leading-relaxed">
+          This will permanently delete your account, all your conversations, and every saved
+          character. This action cannot be undone.
+        </p>
+
+        {error && (
+          <div className="mb-4 rounded-xl border border-brand-status-error/40 bg-brand-status-error/10 px-3 py-2 text-sm text-brand-status-error">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isDeleting}
+            className="rounded-xl border border-brand-surface-border/50 bg-brand-surface-secondary/60 px-4 py-2 text-sm font-medium text-brand-text-secondary transition-all duration-200 hover:bg-brand-surface-elevated/70 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="rounded-xl border border-brand-status-error/45 bg-brand-status-error/15 px-4 py-2 text-sm font-semibold text-brand-status-error transition-all duration-200 hover:bg-brand-status-error/25 disabled:opacity-50"
+          >
+            {isDeleting ? 'Deleting…' : 'Delete account'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Turns the sidebar hamburger menu (formerly "Account menu") into a full menu:

- **Rename** tooltip/aria from `Account menu` to `Menu`
- **Remove** the standalone trash can button; delete now lives in the menu (drag-to-delete still works via the menu button as drop target)
- **Add Delete account** — confirmation modal backed by a new `delete-account` Lambda that removes the Cognito user and their data via an Amplify `deleteAccount` mutation
- **Brain conversations** can no longer be deleted; the menu shows **Clear chat** instead (deletes messages, keeps the conversation). GM conversations keep **Delete current chat**.

## Backend (delete account)
- New `amplify/functions/delete-account/` Lambda (Cognito `AdminDeleteUser` + best-effort DynamoDB cleanup)
- `deleteAccount` mutation added to the data schema (`allow.authenticated()`)
- `backend.ts` wiring: IAM `cognito-idp:AdminDeleteUser` + DynamoDB scan/delete on all data tables

> Note: the `deleteAccount` mutation requires a backend deploy (`npm run deploy:sandbox`) before it works live. Clear chat uses existing data APIs and works now.