### PR TITLE
fix(deploy): co-locate delete-account lambda in data stack

### DIFF
--- a/amplify/functions/delete-account/resource.ts
+++ b/amplify/functions/delete-account/resource.ts
@@ -3,4 +3,5 @@ import { defineFunction } from '@aws-amplify/backend';
 export const deleteAccount = defineFunction({
   name: 'delete-account',
   timeoutSeconds: 60,
+  resourceGroupName: 'data',
 });


### PR DESCRIPTION
Fixes the CloudFormation circular dependency (BrainInCupDashboard, BrainMessageMapping, data, function) that blocked the sandbox deploy after adding the deleteAccount data-resolver function. Assigning the function to the data stack via `resourceGroupName: 'data'` breaks the data <-> function cycle.