### PR TITLE
feat(ui): mobile menu, redesigned brain button, responsive placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { isTestModeEnabled } from './utils/testMode';
 import { streamAgentMessage, type AguiEvent } from './utils/aguiStream';
 import { MessageBubble, type Message } from './components/MessageBubble';
 import DeleteAccountModal from './components/DeleteAccountModal';
+import MobileMenu from './components/MobileMenu';
 const dataClient = generateClient<Schema>();
 
 type AdventureRecord = Schema['GameMasterAdventure']['type'];
@@ -422,6 +423,7 @@ function App() {
   );
   const [expandedMessageIndex, setExpandedMessageIndex] = useState<number | null>(null); // Track which message's details are shown
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDeleteAccountModalOpen, setIsDeleteAccountModalOpen] = useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
   const [deleteAccountError, setDeleteAccountError] = useState<string | null>(null);
@@ -2854,8 +2856,9 @@ function App() {
                         </div>
                       </BottomInput>
                   </section>
-              </div>
-          </main>
+</div>
+      </main>
+
         <aside className="retro-shell-right">
           <div className="retro-right-container flex flex-col h-full overflow-y-auto">
                 {isGameMasterMode ? (
@@ -2971,7 +2974,19 @@ function App() {
         <nav className="retro-nav retro-mobile-nav sticky top-0 z-[60] bg-brand-surface-elevated/95 backdrop-blur-xl border-b border-brand-surface-border/50 shadow-lg pt-safe rounded-3xl">
           <div className="px-4 py-4 space-y-3">
             <div className="flex items-center justify-between">
-              <span className="retro-title text-lg font-light text-brand-text-primary tracking-wide">Brain in Cup</span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setIsMobileMenuOpen(true)}
+                  className="rounded-xl p-2 text-brand-text-primary hover:bg-brand-surface-secondary/60 transition-colors"
+                  aria-label="Open menu"
+                >
+                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.9} d="M4 7h16M4 12h16M4 17h16" />
+                  </svg>
+                </button>
+                <span className="retro-title text-lg font-light text-brand-text-primary tracking-wide">Brain in Cup</span>
+              </div>
             </div>
 
             <div>
@@ -3281,6 +3296,35 @@ function App() {
         </div>
 
       </main>
+
+      {/* Mobile Menu Drawer */}
+      <MobileMenu
+        isOpen={isMobileMenuOpen}
+        onClose={() => setIsMobileMenuOpen(false)}
+        activeConversationId={conversationId === brainConversationId ? 'brain' : conversationId}
+        conversationId={conversationId}
+        effectivePersonality={effectivePersonality}
+        messagesCount={messages.length}
+        displayName={websiteUserProfile.displayName}
+        email={websiteUserProfile.email}
+        onSelectBrain={() => {
+          setIsMobileMenuOpen(false);
+          if (brainConversationId) {
+            setPersonalityMode('brain');
+            void handleSelectConversation(brainConversationId);
+          }
+        }}
+        onSelectConversation={(id) => { void handleSelectConversation(id); }}
+        onNewConversation={() => { void handleNewConversation(); }}
+        onSignOut={handleSignOut}
+        onDeleteCurrent={() => { void handleSidebarDeleteAction(); }}
+        onClearChat={() => { void handleClearBrainChat(); }}
+        onDeleteAccount={() => {
+          setIsProfileMenuOpen(false);
+          setIsMobileMenuOpen(false);
+          setIsDeleteAccountModalOpen(true);
+        }}
+      />
 
       {/* Install Prompt */}
       <InstallPrompt />

--- a/src/components/ConversationSidebarIcons.tsx
+++ b/src/components/ConversationSidebarIcons.tsx
@@ -18,7 +18,7 @@ type ConversationMetadata = {
   updatedAt: string;
 };
 
-const readStoredAvatarId = (conversationId: string): string => {
+export const readStoredAvatarId = (conversationId: string): string => {
   if (typeof window === 'undefined' || !conversationId) return '';
   try {
     const raw = window.localStorage.getItem(GM_CONVERSATION_AVATAR_STORAGE_KEY);
@@ -44,7 +44,7 @@ const writeConversationCache = (metadata: ConversationMetadata[]) => {
   } catch { /* ignore */ }
 };
 
-const CHAT_LIMIT = 3;
+export const CHAT_LIMIT = 3;
 
 interface ConversationSidebarIconsProps {
   onSelectConversation: (conversationId: string) => void;

--- a/src/components/ConversationSidebarIcons.tsx
+++ b/src/components/ConversationSidebarIcons.tsx
@@ -170,18 +170,18 @@ export default function ConversationSidebarIcons({
             if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
             setHoveredId(null);
           }}
-          className={`h-12 w-12 rounded-xl transition-all duration-200 flex items-center justify-center shrink-0 border-2 outline-none focus:outline-none ${
+          className={`h-10 w-10 rounded-lg transition-all duration-200 flex items-center justify-center shrink-0 border-2 outline-none focus:outline-none ${
             activeConversationId === 'brain'
-              ? 'border-brand-surface-border/60 bg-brand-surface-dark/60 scale-95'
-              : 'border-violet-400/60 bg-gradient-to-br from-violet-500/20 to-fuchsia-500/20 shadow-[0_0_12px_rgba(139,92,246,0.3)] hover:shadow-[0_0_20px_rgba(139,92,246,0.5)] hover:scale-110'
+              ? 'border-violet-400/80 bg-gradient-to-br from-violet-500/35 to-fuchsia-500/25 scale-95 shadow-[0_0_14px_rgba(139,92,246,0.4)]'
+              : 'border-violet-400/50 bg-gradient-to-br from-violet-500/20 to-fuchsia-500/20 hover:border-violet-400/75 hover:from-violet-500/28 hover:to-fuchsia-500/28'
           }`}
         >
           <img
-            src="/brain-icon.svg"
+            src="/brain-chat.svg"
             alt="Brain"
-            className="h-8 w-8 object-contain brightness-0 invert"
+            className="h-8 w-8 object-contain drop-shadow-[0_2px_6px_rgba(0,0,0,0.45)]"
             onError={(e) => {
-              // Fallback to emoji if SVG doesn't exist
+              // Fallback to emoji if the image doesn't exist
               e.currentTarget.style.display = 'none';
               const parent = e.currentTarget.parentElement;
               if (parent && !parent.querySelector('.brain-fallback')) {

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -3,6 +3,7 @@ import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { getAvatarSrcById, getAvatarWebpSrcById } from '../constants/gameMasterAvatars';
 import { normalizePersonalityMode } from '../constants/personalityModes';
+import { CHAT_LIMIT, readStoredAvatarId } from './ConversationSidebarIcons';
 
 const dataClient = generateClient<Schema>();
 
@@ -85,10 +86,11 @@ export default function MobileMenu({
             });
             avatarId = chars?.[0]?.avatarId || '';
           } catch { /* ignore */ }
+          const resolvedAvatarId = avatarId || readStoredAvatarId(c.id);
           items.push({
             id: c.id,
-            avatarSrc: avatarId ? getAvatarSrcById(avatarId) : '',
-            avatarSrcWebp: avatarId ? getAvatarWebpSrcById(avatarId) : '',
+            avatarSrc: resolvedAvatarId ? getAvatarSrcById(resolvedAvatarId) : '',
+            avatarSrcWebp: resolvedAvatarId ? getAvatarWebpSrcById(resolvedAvatarId) : '',
             title: c.title || 'Untitled',
           });
         }
@@ -100,6 +102,7 @@ export default function MobileMenu({
 
   if (!isOpen) return null;
   const isGameMaster = effectivePersonality === 'game_master';
+  const adventures = conversations.filter(c => c.avatarSrc);
   const operations =
     (active: boolean) =>
       `flex w-full items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors border ${
@@ -161,12 +164,15 @@ export default function MobileMenu({
 
           <div className="my-3 h-px bg-brand-surface-border/50" />
 
-          <p className="px-3 text-[10px] font-medium uppercase tracking-wider text-brand-text-muted/60">Adventures</p>
+          <div className="flex items-center justify-between px-3">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-brand-text-muted/60">Adventures</p>
+            <p className="text-[10px] font-medium text-brand-text-muted/60">{adventures.length}/{CHAT_LIMIT} open</p>
+          </div>
           <div className="mt-1 space-y-1">
-            {conversations.length === 0 && (
+            {adventures.length === 0 && (
               <p className="px-3 py-2 text-xs text-brand-text-muted/60">No adventures yet</p>
             )}
-            {conversations.map((conv) => (
+            {adventures.map((conv) => (
               <button
                 key={conv.id}
                 type="button"
@@ -174,11 +180,7 @@ export default function MobileMenu({
                 className={operations(conversationId === conv.id)}
               >
                 <span className="h-9 w-9 shrink-0 overflow-hidden rounded-lg border border-brand-surface-border/50">
-                  {conv.avatarSrc ? (
-                    <img src={conv.avatarSrc} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
-                  ) : (
-                    <span className="flex h-full w-full items-center justify-center text-lg">⚔️</span>
-                  )}
+                  <img src={conv.avatarSrc} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-sm font-medium text-brand-text-primary">{conv.title}</span>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+import { getAvatarSrcById, getAvatarWebpSrcById } from '../constants/gameMasterAvatars';
+import { normalizePersonalityMode } from '../constants/personalityModes';
+
+const dataClient = generateClient<Schema>();
+
+const CONVERSATION_CACHE_KEY = 'conversationMetadataCache';
+
+type ConversationMeta = {
+  id: string;
+  avatarSrc: string;
+  avatarSrcWebp: string;
+  title: string;
+};
+
+interface MobileMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activeConversationId: string | null;
+  conversationId: string | null;
+  effectivePersonality: 'brain' | 'game_master';
+  messagesCount: number;
+  displayName: string;
+  email: string;
+  onSelectBrain: () => void;
+  onSelectConversation: (id: string) => void;
+  onNewConversation: () => void;
+  onSignOut: () => void;
+  onDeleteCurrent: () => void;
+  onClearChat: () => void;
+  onDeleteAccount: () => void;
+}
+
+const readConversationCache = (): ConversationMeta[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(CONVERSATION_CACHE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ConversationMeta[];
+    return parsed.filter(c => c && c.id);
+  } catch { return []; }
+};
+
+export default function MobileMenu({
+  isOpen,
+  onClose,
+  activeConversationId,
+  conversationId,
+  effectivePersonality,
+  messagesCount,
+  displayName,
+  email,
+  onSelectBrain,
+  onSelectConversation,
+  onNewConversation,
+  onSignOut,
+  onDeleteCurrent,
+  onClearChat,
+  onDeleteAccount,
+}: MobileMenuProps) {
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setConversations(readConversationCache());
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data: rows } = await dataClient.models.Conversation.list();
+        const gm = (rows || [])
+          .filter(c => normalizePersonalityMode(c.personalityMode || 'brain') === 'game_master')
+          .sort((a, b) => new Date(a.updatedAt || a.createdAt || 0).getTime() - new Date(b.updatedAt || b.createdAt || 0).getTime());
+
+        const items: ConversationMeta[] = [];
+        for (const c of gm) {
+          if (!c.id) continue;
+          let avatarId = '';
+          try {
+            const { data: chars } = await dataClient.models.GameMasterCharacter.list({
+              filter: { conversationId: { eq: c.id } },
+              limit: 1,
+              authMode: 'userPool',
+            });
+            avatarId = chars?.[0]?.avatarId || '';
+          } catch { /* ignore */ }
+          items.push({
+            id: c.id,
+            avatarSrc: avatarId ? getAvatarSrcById(avatarId) : '',
+            avatarSrcWebp: avatarId ? getAvatarWebpSrcById(avatarId) : '',
+            title: c.title || 'Untitled',
+          });
+        }
+        if (!cancelled) setConversations(items);
+      } catch { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+  const isGameMaster = effectivePersonality === 'game_master';
+  const operations =
+    (active: boolean) =>
+      `flex w-full items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors border ${
+        active ? 'bg-brand-surface-secondary/60 border-brand-accent-primary/40' : 'hover:bg-brand-surface-secondary/50 border-transparent'
+      }`;
+
+  return (
+    <div className="lg:hidden fixed inset-0 z-[70]">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+      <div className="absolute left-0 top-0 h-full w-[300px] max-w-[80vw] flex flex-col bg-brand-surface-elevated/95 backdrop-blur-xl border-r border-brand-surface-border/50 shadow-2xl animate-slide-in-left">
+        <div className="flex items-center justify-between px-4 py-4 border-b border-brand-surface-border/50">
+          <div className="flex items-center gap-2">
+            <img src="/brain-icon.svg" alt="Brain" className="h-6 w-6 object-contain brightness-0 invert" />
+            <span className="retro-title text-base font-light text-brand-text-primary tracking-wide">Brain in Cup</span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl p-2 text-brand-text-muted hover:text-brand-text-primary transition-colors"
+            aria-label="Close menu"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto p-2">
+          <button
+            type="button"
+            onClick={() => { onSelectBrain(); onClose(); }}
+            className={`flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left border transition-colors ${
+              activeConversationId === 'brain'
+                ? 'border-violet-400/40 bg-gradient-to-br from-violet-500/25 to-fuchsia-500/15'
+                : 'border-transparent hover:bg-brand-surface-secondary/50'
+            }`}
+          >
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-violet-400/50 overflow-hidden bg-gradient-to-br from-violet-500/20 to-fuchsia-500/20">
+              <img src="/brain-chat.svg" alt="" className="h-8 w-8 object-contain" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-brand-text-primary">Brain</span>
+              <span className="block text-xs text-brand-text-muted">Agent co-pilot</span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => { onNewConversation(); onClose(); }}
+            className="mt-1 flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left border border-transparent hover:bg-brand-surface-secondary/50 transition-colors"
+          >
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-brand-surface-border/50 bg-brand-surface-secondary/60">
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14M5 12h14" />
+              </svg>
+            </span>
+            <span className="text-sm font-medium text-brand-text-primary">New chat</span>
+          </button>
+
+          <div className="my-3 h-px bg-brand-surface-border/50" />
+
+          <p className="px-3 text-[10px] font-medium uppercase tracking-wider text-brand-text-muted/60">Adventures</p>
+          <div className="mt-1 space-y-1">
+            {conversations.length === 0 && (
+              <p className="px-3 py-2 text-xs text-brand-text-muted/60">No adventures yet</p>
+            )}
+            {conversations.map((conv) => (
+              <button
+                key={conv.id}
+                type="button"
+                onClick={() => { onSelectConversation(conv.id); onClose(); }}
+                className={operations(conversationId === conv.id)}
+              >
+                <span className="h-9 w-9 shrink-0 overflow-hidden rounded-lg border border-brand-surface-border/50">
+                  {conv.avatarSrc ? (
+                    <img src={conv.avatarSrc} alt="" className="h-full w-full object-cover" loading="lazy" decoding="async" />
+                  ) : (
+                    <span className="flex h-full w-full items-center justify-center text-lg">⚔️</span>
+                  )}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-brand-text-primary">{conv.title}</span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="border-t border-brand-surface-border/50 p-2">
+          <div className="mx-1 mb-1 px-1">
+            <p className="truncate text-xs font-medium text-brand-text-primary">{displayName}</p>
+            <p className="truncate text-[11px] text-brand-text-muted">{email}</p>
+          </div>
+          {isGameMaster ? (
+            <button
+              type="button"
+              onClick={() => { onDeleteCurrent(); onClose(); }}
+              disabled={!conversationId}
+              className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-status-error disabled:opacity-45"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              Delete current chat
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => { onClearChat(); onClose(); }}
+              disabled={!conversationId || messagesCount === 0}
+              className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-muted hover:text-brand-text-primary disabled:opacity-45"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              Clear chat
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => { onSignOut(); }}
+            className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-text-primary"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+            Sign out
+          </button>
+          <button
+            type="button"
+            onClick={() => { onDeleteAccount(); }}
+            className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-brand-status-error"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Delete account
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -927,6 +927,10 @@ textarea.w-full:focus {
 
 .retro-input-textarea::placeholder {
   color: rgba(205, 231, 225, 0.62) !important;
+  font-size: clamp(0.8125rem, 0.7rem + 0.6vw, 0.9375rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .retro-send-button {

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,19 @@ textarea.w-full:focus {
   animation: slide-up 0.3s ease-out;
 }
 
+@keyframes slide-in-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-left {
+  animation: slide-in-left 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 /* ─── RPG Theme Tokens ─── */
 :root {
   --rpg-accent: #79d7c2;


### PR DESCRIPTION
## Changes
- New sliding **mobile menu** drawer (hamburger in mobile nav) with Brain, New chat, adventures list, and account actions.
- Adventures list mirrors desktop sidebar logic: reuses shared `CHAT_LIMIT` / `readStoredAvatarId`, shows real avatars, filters to chats with avatars, and displays an `x/3 open` count.
- Sidebar Brain button now uses the branded `brain-chat.svg`.
- Input placeholder scales with viewport (`clamp()`) and stays single-line with ellipsis.

Closes long-standing mobile navigation gap.