### PR TITLE
fix(gm): make combat reachable and survive stale adventure rows

### DIFF
--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/content.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/content.py
@@ -139,6 +139,16 @@ ENEMIES: dict[str, dict] = {
         "xp_value": 12,
         "is_hostile": True,
     },
+    "bar_brawler": {
+        "id": "bar_brawler",
+        "name": "Brawling Patron",
+        "armor_class": 12,
+        "hit_points": 10,
+        "attack_modifier": 3,
+        "damage": "1d4+1",
+        "xp_value": 25,
+        "is_hostile": True,
+    },
 }
 
 # ---------------------------------------------------------------------------
@@ -235,6 +245,11 @@ DEFAULT_LEVEL_XP = 100
 
 def get_location(location_id: Optional[str]) -> Optional[dict]:
     return LOCATIONS.get(location_id or "")
+
+
+def resolve_location(location_id: Optional[str]) -> dict:
+    """Like get_location but never returns None — unknown ids fall back to STARTING_LOCATION."""
+    return LOCATIONS.get(location_id or "") or LOCATIONS[STARTING_LOCATION]
 
 
 def get_npc(npc_id: Optional[str]) -> Optional[dict]:

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/intent.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/intent.py
@@ -32,9 +32,10 @@ ALL_MODES = [
 ]
 
 _LABELS: dict[tuple[str, ...], str] = {
-    ("fighting", "attack", "hit", "kill", "strike", "slash", "swing", "stab",
-     "shoot", "draw", "fire", "charge", "engage", "defend", "guard", "block",
-     "rat", "foe", "enemy"): COMBAT_MODE,
+    ("fighting", "attack", "hit", "hit the", "kill", "strike", "slash", "swing",
+     "stab", "punch", "kick", "shove", "grapple", "assault", "brawl", "slug",
+     "club", "smash", "smack", "shoot", "draw", "fire", "charge", "engage",
+     "defend", "guard", "block", "rat", "foe", "enemy"): COMBAT_MODE,
     ("talk", "speak", "say", "ask", "greet", "converse", "hello", "hi ",
      "who", "tell", "chat", "relate", "npc"): DIALOGUE_MODE,
     ("look", "examine", "inspect", "search", "explore", "go ", "travel",

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/nodes.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/nodes.py
@@ -154,6 +154,14 @@ def _enemy_present(campaign: dict) -> bool:
     return True
 
 
+def _wants_brawl(user_input: str) -> bool:
+    """True when the player aggresses unarmed detail or picks a fight unprompted."""
+    text = " " + (user_input or "").lower()
+    attacks = ("fight", "fighting", "attack", "hit the", "punch", "kick", "shove",
+               "slug", "smack", "assault", "brawl", "grab", "start a", "throw a")
+    return any(t in text for t in attacks)
+
+
 # ---------------------------------------------------------------------------
 # Opening
 # ---------------------------------------------------------------------------
@@ -233,7 +241,7 @@ def exploration_node(state: OrchestratorState) -> dict:
             f"Connections: {', '.join(moved.get('connections', []))}",
         ]
     else:
-        loc = content.get_location(campaign.get("currentLocation", content.STARTING_LOCATION))
+        loc = content.resolve_location(campaign.get("currentLocation", content.STARTING_LOCATION))
         facts = [
             f"You remain in: {loc['name']}.",
             f"{loc['description']}",
@@ -262,19 +270,27 @@ def combat_node(state: OrchestratorState) -> dict:
     campaign = dict(state.get("campaign", {}) or {})
     player = state.get("player", {})
     store = state.get("store")
-    enemy_id = content.get_location(campaign.get("currentLocation"))
-    enemy_ids = (enemy_id or {}).get("enemies") or []
+    loc = content.resolve_location(campaign.get("currentLocation", content.STARTING_LOCATION))
+    enemy_ids = (loc or {}).get("enemies") or []
     enemy = content.get_enemy(enemy_ids[0] if enemy_ids else None)
 
     if enemy is None or not _enemy_present(campaign):
-        loc = content.get_location(campaign.get("currentLocation"))
-        text = generate_narration(state.get("system_prompt", ORCHESTRATOR_SYSTEM_PROMPT),
-                                  _facts_prompt(state, [f"No enemy here ({loc['name']})."]),
-                                  model_id=state.get("model_id"), region=state.get("region"))
-        return {"final_message": text}
+        # No scripted foe here, but an aggressive/combat command can start a brawl
+        # against whoever is present so the player is never soft-locked out of fights.
+        if _wants_brawl(state.get("user_input", "")):
+            enemy = content.get_enemy("bar_brawler")
+            facts = ["You throw yourself into the fight against a brawling patron."]
+        else:
+            facts = [f"No enemy here ({loc['name']})."]
+            text = generate_narration(state.get("system_prompt", ORCHESTRATOR_SYSTEM_PROMPT),
+                                      _facts_prompt(state, facts),
+                                      model_id=state.get("model_id"), region=state.get("region"))
+            return {"final_message": text}
+    else:
+        facts = []
 
     result = systems.player_attack(player, enemy)
-    facts = [
+    facts += [
         f"attack roll={result['roll']} vs AC {enemy['armor_class']}: "
         f"{'HIT' if result['hit'] else 'MISS'}"
         + (f" for {result['damage']} damage." if result['hit'] else "."),
@@ -282,10 +298,12 @@ def combat_node(state: OrchestratorState) -> dict:
     ]
 
     if result["enemy_defeated"]:
-        campaign["activeObjectives"] = {"quest_id": content.QUEST_ID, "status": "IN_PROGRESS", "step": "clear_cellar"}
+        is_cellar_rat = enemy["id"] == "cellar_rat"
+        if is_cellar_rat:
+            campaign["activeObjectives"] = {"quest_id": content.QUEST_ID, "status": "IN_PROGRESS", "step": "clear_cellar"}
         xp = content.ENEMIES[enemy["id"]]["xp_value"]
         player = dict(player)
-        facts.append(f"The cellar rat is defeated. You gain {xp} XP.")
+        facts.append(f"{enemy['name']} is defeated. You gain {xp} XP.")
         if player:
             player = systems.apply_xp(player, xp)
         if store is not None:

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/nodes.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/nodes.py
@@ -245,7 +245,7 @@ def exploration_node(state: OrchestratorState) -> dict:
         facts = [
             f"You remain in: {loc['name']}.",
             f"{loc['description']}",
-            f"Present NPCS: {', '.join(n['name'] for n in _npcs_at(loc))}",
+            f"Present NPCS: {', '.join(n['name'] for n in _content_npcs(loc))}",
         ]
 
     # Recover the lantern once the cellar rats are gone.

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
@@ -166,12 +166,20 @@ class OrchestrationStore:
             IndexName=self._conversation_index(self.adventure_table),
             KeyConditionExpression="conversationId = :c",
             ExpressionAttributeValues={":c": {"S": conversation_id}},
-            Limit=1,
         )
-        items = resp.get("Items", [])
-        if not items:
+        items = resp.get("Items", []) or []
+        # The GameMasterAdventure table is shared with a legacy adventure engine
+        # that writes free-text rows (a new row per turn). Prefer the most recent
+        # row whose location is a known content key; otherwise start fresh.
+        known = [
+            it for it in items
+            if content.get_location(self._s(it.get("currentLocation"))) is not None
+        ]
+        pool = known or items
+        pool = sorted(pool, key=lambda it: self._s(it.get("updatedAt")), reverse=True)
+        if not pool:
             return self._fresh_campaign(conversation_id)
-        item = items[0]
+        item = pool[0]
         return {
             "id": self._s(item.get("id")),
             "conversation_id": conversation_id,

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
@@ -169,14 +169,14 @@ class OrchestrationStore:
         )
         items = resp.get("Items", []) or []
         # The GameMasterAdventure table is shared with a legacy adventure engine
-        # that writes free-text rows (a new row per turn). Prefer the most recent
-        # row whose location is a known content key; otherwise start fresh.
+        # that writes free-text rows (a new row per turn). Prefer rows whose
+        # location is a known content key; if none exist, start fresh rather than
+        # inherit an unresolvable free-text location that would crash gameplay.
         known = [
             it for it in items
             if content.get_location(self._s(it.get("currentLocation"))) is not None
         ]
-        pool = known or items
-        pool = sorted(pool, key=lambda it: self._s(it.get("updatedAt")), reverse=True)
+        pool = sorted(known, key=lambda it: self._s(it.get("updatedAt")), reverse=True)
         if not pool:
             return self._fresh_campaign(conversation_id)
         item = pool[0]

--- a/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
+++ b/amplify/functions/brain/src/experiences/game_master/orchestrator/persistence.py
@@ -213,13 +213,13 @@ class OrchestrationStore:
         adventure_id = str(uuid.uuid4())
         self.adventure_table.put_item(
             Item={
-                "id": {"S": adventure_id},
-                "conversationId": {"S": conversation_id},
-                "started": {"BOOL": False},
-                "currentLocation": {"S": campaign.get("currentLocation", content.STARTING_LOCATION)},
-                "visitedLocations": {"L": [{"S": loc} for loc in (campaign.get("visitedLocations") or [])]},
-                "createdAt": {"S": self._now()},
-                "updatedAt": {"S": self._now()},
+                "id": adventure_id,
+                "conversationId": conversation_id,
+                "started": False,
+                "currentLocation": campaign.get("currentLocation", content.STARTING_LOCATION),
+                "visitedLocations": campaign.get("visitedLocations") or [],
+                "createdAt": self._now(),
+                "updatedAt": self._now(),
             },
         )
         campaign["id"] = adventure_id
@@ -251,15 +251,15 @@ class OrchestrationStore:
         quest_id = f"{conversation_id}:{quest['id']}"
         self.active_quest_table.put_item(
             Item={
-                "id": {"S": quest_id},
-                "playerStateId": {"S": character_id},
-                "questDefinitionId": {"S": quest["id"]},
-                "campaignId": {"S": content.GREENFIELD_CAMPAIGN_ID},
-                "status": {"S": "ACTIVE"},
-                "currentStepIndex": {"N": "0"},
-                "totalSteps": {"N": str(len(quest.get("steps", [])))},
-                "startedAt": {"S": self._now()},
-                "owner": {"S": character_id},
+                "id": quest_id,
+                "playerStateId": character_id,
+                "questDefinitionId": quest["id"],
+                "campaignId": content.GREENFIELD_CAMPAIGN_ID,
+                "status": "ACTIVE",
+                "currentStepIndex": 0,
+                "totalSteps": len(quest.get("steps", [])),
+                "startedAt": self._now(),
+                "owner": character_id,
             },
         )
         return quest_id

--- a/amplify/functions/brain/src/tests/test_orchestrator.py
+++ b/amplify/functions/brain/src/tests/test_orchestrator.py
@@ -26,6 +26,13 @@ class IntentRoutingTest(unittest.TestCase):
         for text, expected in cases.items():
             self.assertEqual(intent.classify_intent(text), expected, text)
 
+    def test_unarmed_aggression_is_combat(self):
+        for text in ("I punch the first guy in the face",
+                     "I kick the table over",
+                     "Start a fight with the guard",
+                     "I smash the mug on the floor"):
+            self.assertEqual(intent.classify_intent(text), intent.COMBAT_MODE, text)
+
     def test_never_none(self):
         for _ in range(200):
             self.assertIn(intent.classify_intent("the fire crackles oddly"), intent.ALL_MODES)
@@ -81,3 +88,11 @@ class ContentCompletenessTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class ContentResilienceTest(unittest.TestCase):
+    def test_resolve_location_falls_back_on_unknown(self):
+        self.assertEqual(content.resolve_location("The Shrouded Vale")["id"],
+                         content.STARTING_LOCATION)
+        self.assertEqual(content.resolve_location(None)["id"], content.STARTING_LOCATION)
+        self.assertEqual(content.resolve_location("whispering_tankard")["id"],
+                         "whispering_tankard")


### PR DESCRIPTION
Fixes why the Game Master stopped responding to player messages ("punch someone" → no reply) and makes fights reachable.

**Root causes fixed**
1. **Mixed boto layers in persistence writes** — reads use the low-level client; writes used resource `Table.put_item` with manually-typed `{"S": ...}` maps, which DynamoDB double-encoded into a Map (`Type mismatch for key id expected: S actual: M`). Every campaign/quest write crashed whole turns. All writes now use plain values the resource auto-encodes.
2. **Stale shared adventure rows** — the `GameMasterAdventure` table is shared with a legacy engine writing free-text rows (e.g. `currentLocation: "The Shrouded Vale"`, a new row per turn). `load_campaign` now only loads the newest row whose location is a known content key, and falls back to a fresh campaign otherwise, so exploration never crashes on an unresolvable location.
3. **Location resolution** — added `resolve_location` that falls back to `alderheart_square` instead of `None['name']` crashes.
4. **Combat intent** — added martial verbs (`punch`, `kick`, `grapple`, `smash`…) so unarmed aggression routes to COMBAT.
5. **Brawling** — when the player aggresses in a scene with no scripted foe, spawns a `bar_brawler` fight instead of a soft-lock "no enemy here".
6. **NPC helper** — `exploration_node` referenced undefined `_npcs_at`; now uses `_content_npcs`.

All 10 orchestrator tests pass; verified end-to-end live.